### PR TITLE
Add main to list of branches in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ on:
       - v*
     branches:
       - master
+      - main
   pull_request:
 jobs:
   golangci:
@@ -63,6 +64,7 @@ on:
       - v*
     branches:
       - master
+      - main
   pull_request:
 jobs:
   golangci:


### PR DESCRIPTION
Recently GitHub switched default branch name to `main` from `master`, this affects new repositories.

This PR updates examples in README to use both `master` and `main`.