### PR TITLE
Add a skip-go-installation to use pre-installed Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ jobs:
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go
+          # skip-go-installation: true
 ```
 
 We recommend running this action in a job separate from other jobs (`go test`, etc)
@@ -94,7 +97,7 @@ jobs:
 You will also likely need to add the following `.gitattributes` file to ensure that line endings for windows builds are properly formatted:
 
 ```.gitattributes
-*.go text eol=lf 
+*.go text eol=lf
 ```
 
 ## Comments and Annotations

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,3 @@
----
 name: "Run golangci-lint"
 description: "Official golangci-lint action with line-attached annotations for found issues, caching and parallel execution."
 author: "golangci"
@@ -21,7 +20,10 @@ inputs:
     description: "if set to true and the action runs on a pull request - the action outputs only newly found issues"
     default: false
     required: true
-
+  skip-go-installation:
+    description: "if set to true then action uses pre-installed Go"
+    default: false
+    required: true
 runs:
   using: "node12"
   main: "dist/run/index.js"

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -7169,6 +7169,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const { lintPath, patchPath } = yield core.group(`prepare environment`, prepareEnv);
+            core.addPath(path.dirname(lintPath));
             yield core.group(`run golangci-lint`, () => runLint(lintPath, patchPath));
         }
         catch (error) {
@@ -48591,6 +48592,11 @@ function installLint(versionConfig) {
 exports.installLint = installLint;
 function installGo() {
     return __awaiter(this, void 0, void 0, function* () {
+        const skipGoInstallation = core.getInput(`skip-go-installation`, { required: true }).trim();
+        if (skipGoInstallation.toLowerCase() == "true") {
+            core.info(`Skipping the installation of Go`);
+            return;
+        }
         const startedAt = Date.now();
         process.env[`INPUT_GO-VERSION`] = `1`;
         yield main_1.run();

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -7179,6 +7179,7 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const { lintPath, patchPath } = yield core.group(`prepare environment`, prepareEnv);
+            core.addPath(path.dirname(lintPath));
             yield core.group(`run golangci-lint`, () => runLint(lintPath, patchPath));
         }
         catch (error) {
@@ -48601,6 +48602,11 @@ function installLint(versionConfig) {
 exports.installLint = installLint;
 function installGo() {
     return __awaiter(this, void 0, void 0, function* () {
+        const skipGoInstallation = core.getInput(`skip-go-installation`, { required: true }).trim();
+        if (skipGoInstallation.toLowerCase() == "true") {
+            core.info(`Skipping the installation of Go`);
+            return;
+        }
         const startedAt = Date.now();
         process.env[`INPUT_GO-VERSION`] = `1`;
         yield main_1.run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "tmp": "^0.2.1"
       },
       "devDependencies": {
-        "@types/node": "^14.14.13",
+        "@types/node": "^14.14.16",
         "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^2.34.0",
         "@typescript-eslint/parser": "^2.34.0",
@@ -502,9 +502,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.13.tgz",
-      "integrity": "sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ=="
+      "version": "14.14.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
+      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.7",

--- a/src/install.ts
+++ b/src/install.ts
@@ -56,6 +56,12 @@ export async function installLint(versionConfig: VersionConfig): Promise<string>
 }
 
 export async function installGo(): Promise<void> {
+  const skipGoInstallation = core.getInput(`skip-go-installation`, { required: true }).trim()
+  if (skipGoInstallation.toLowerCase() == "true") {
+    core.info(`Skipping the installation of Go`)
+    return
+  }
+
   const startedAt = Date.now()
   process.env[`INPUT_GO-VERSION`] = `1`
   await setupGo()

--- a/src/run.ts
+++ b/src/run.ts
@@ -187,6 +187,7 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
 export async function run(): Promise<void> {
   try {
     const { lintPath, patchPath } = await core.group(`prepare environment`, prepareEnv)
+    core.addPath(path.dirname(lintPath))
     await core.group(`run golangci-lint`, () => runLint(lintPath, patchPath))
   } catch (error) {
     core.error(`Failed to run: ${error}, ${error.stack}`)


### PR DESCRIPTION
Add a `skip-go-installation` parameter in action. If it is set to true, the pre-installed go is used
Add the `golangci-lint` binary to PATH

closes #75