### PR TITLE
Fix a typo in README.md (it's->its)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/golangci/golangci-lint-action/workflows/build-and-test/badge.svg)](https://github.com/golangci/golangci-lint-action/actions)
 
-It's the official GitHub action for [golangci-lint](https://github.com/golangci/golangci-lint) from it's authors.
+It's the official GitHub action for [golangci-lint](https://github.com/golangci/golangci-lint) from its authors.
 The action runs [golangci-lint](https://github.com/golangci/golangci-lint) and reports issues from linters.
 
 ![GitHub Annotations](./static/annotations.png)


### PR DESCRIPTION
- ~_it's_~ = it _is_ (or _has_)
- **its** - possessive pronoun of _it_ (something belongs to _it_)

See https://www.grammarly.com/blog/possessive-pronouns/: _A Common Mistake: Its vs. It’s_

The same applies for the repository description:

![golangci-lint-action-desc-its-typo](https://user-images.githubusercontent.com/47499687/105553829-72ac1800-5d06-11eb-97c7-ed8ff512df5e.gif)