### PR TITLE
Add options to skip caching of folders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,14 @@ jobs:
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
-          # Optional: if set to true then the action will use pre-installed Go
+          # Optional: if set to true then the action will use pre-installed Go.
           # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true
 ```
 
 We recommend running this action in a job separate from other jobs (`go test`, etc)

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,14 @@ inputs:
     description: "if set to true then action uses pre-installed Go"
     default: false
     required: true
+  skip-pkg-cache:
+    description: "if set to true then the action don't cache or restore ~/go/pkg."
+    default: false
+    required: true
+  skip-build-cache:
+    description: "if set to true then the action don't cache or restore ~/.cache/go-build."
+    default: false
+    required: true
 runs:
   using: "node12"
   main: "dist/run/index.js"

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -49992,7 +49992,22 @@ const getLintCacheDir = () => {
 };
 const getCacheDirs = () => {
     // Not existing dirs are ok here: it works.
-    return [getLintCacheDir(), path_1.default.resolve(`${process.env.HOME}/.cache/go-build`), path_1.default.resolve(`${process.env.HOME}/go/pkg`)];
+    const skipPkgCache = core.getInput(`skip-pkg-cache`, { required: true }).trim();
+    const skipBuildCache = core.getInput(`skip-build-cache`, { required: true }).trim();
+    const dirs = [getLintCacheDir()];
+    if (skipBuildCache.toLowerCase() == "true") {
+        core.info(`Omitting ~/.cache/go-build from cache directories`);
+    }
+    else {
+        dirs.push(path_1.default.resolve(`${process.env.HOME}/.cache/go-build`));
+    }
+    if (skipPkgCache.toLowerCase() == "true") {
+        core.info(`Omitting ~/go/pkg from cache directories`);
+    }
+    else {
+        dirs.push(path_1.default.resolve(`${process.env.HOME}/go/pkg`));
+    }
+    return dirs;
 };
 const getIntervalKey = (invalidationIntervalDays) => {
     const now = new Date();

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -50002,7 +50002,22 @@ const getLintCacheDir = () => {
 };
 const getCacheDirs = () => {
     // Not existing dirs are ok here: it works.
-    return [getLintCacheDir(), path_1.default.resolve(`${process.env.HOME}/.cache/go-build`), path_1.default.resolve(`${process.env.HOME}/go/pkg`)];
+    const skipPkgCache = core.getInput(`skip-pkg-cache`, { required: true }).trim();
+    const skipBuildCache = core.getInput(`skip-build-cache`, { required: true }).trim();
+    const dirs = [getLintCacheDir()];
+    if (skipBuildCache.toLowerCase() == "true") {
+        core.info(`Omitting ~/.cache/go-build from cache directories`);
+    }
+    else {
+        dirs.push(path_1.default.resolve(`${process.env.HOME}/.cache/go-build`));
+    }
+    if (skipPkgCache.toLowerCase() == "true") {
+        core.info(`Omitting ~/go/pkg from cache directories`);
+    }
+    else {
+        dirs.push(path_1.default.resolve(`${process.env.HOME}/go/pkg`));
+    }
+    return dirs;
 };
 const getIntervalKey = (invalidationIntervalDays) => {
     const now = new Date();

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -25,7 +25,22 @@ const getLintCacheDir = (): string => {
 
 const getCacheDirs = (): string[] => {
   // Not existing dirs are ok here: it works.
-  return [getLintCacheDir(), path.resolve(`${process.env.HOME}/.cache/go-build`), path.resolve(`${process.env.HOME}/go/pkg`)]
+  const skipPkgCache = core.getInput(`skip-pkg-cache`, { required: true }).trim()
+  const skipBuildCache = core.getInput(`skip-build-cache`, { required: true }).trim()
+  const dirs = [getLintCacheDir()]
+
+  if (skipBuildCache.toLowerCase() == "true") {
+    core.info(`Omitting ~/.cache/go-build from cache directories`)
+  } else {
+    dirs.push(path.resolve(`${process.env.HOME}/.cache/go-build`))
+  }
+  if (skipPkgCache.toLowerCase() == "true") {
+    core.info(`Omitting ~/go/pkg from cache directories`)
+  } else {
+    dirs.push(path.resolve(`${process.env.HOME}/go/pkg`))
+  }
+
+  return dirs
 }
 
 const getIntervalKey = (invalidationIntervalDays: number): string => {


### PR DESCRIPTION
Fix #153.

- Add option to skip caching the Go package directory (`~/go/pkg`).
- Add option to skip caching the Go build directory (`~/.cache/go-build`).
- Update README to mention new options.
