### PR TITLE
Update "version" config in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29
 
           # Optional: working directory, useful for monorepos


### PR DESCRIPTION
#98 was closed by #101, but the README still says that only a major-minor version is accepted. It also says that this field is required, but `action.yml` says otherwise. Copy the description from `action.yml` into the README for consistency.