### PR TITLE
Add option to not fail on only Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ jobs:
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
+
+          # Optional: if set to true then the action don't fail with just golangci-lint warnings.
+          # allow-warnings: true
 ```
 
 We recommend running this action in a job separate from other jobs (`go test`, etc)

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "if set to true then the action don't cache or restore ~/.cache/go-build."
     default: false
     required: true
+  allow-warnings:
+    description: "if set to true then the action don't fail with just golangci-lint warnings."
+    default: false
+    required: false
 runs:
   using: "node12"
   main: "dist/run/index.js"

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6860,7 +6860,14 @@ function runLint(lintPath, patchPath) {
             // TODO: support reviewdog or leaving comments by GitHub API.
             printOutput(exc);
             if (exc.code === 1) {
-                core.setFailed(`issues found`);
+                const allowWarnings = core.getInput(`allow-warnings`, { required: true }).trim();
+                const errorRegex = /^::error.+$/m;
+                if (allowWarnings.toLowerCase() == "true" && !exc.stdout.match(errorRegex)) {
+                    core.info(`golangci-lint found no errors`);
+                }
+                else {
+                    core.setFailed(`issues found`);
+                }
             }
             else {
                 core.setFailed(`golangci-lint exit with code ${exc.code}`);

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6870,7 +6870,14 @@ function runLint(lintPath, patchPath) {
             // TODO: support reviewdog or leaving comments by GitHub API.
             printOutput(exc);
             if (exc.code === 1) {
-                core.setFailed(`issues found`);
+                const allowWarnings = core.getInput(`allow-warnings`, { required: true }).trim();
+                const errorRegex = /^::error.+$/m;
+                if (allowWarnings.toLowerCase() == "true" && !exc.stdout.match(errorRegex)) {
+                    core.info(`golangci-lint found no errors`);
+                }
+                else {
+                    core.setFailed(`issues found`);
+                }
             }
             else {
                 core.setFailed(`golangci-lint exit with code ${exc.code}`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -175,7 +175,13 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
     printOutput(exc)
 
     if (exc.code === 1) {
-      core.setFailed(`issues found`)
+      const allowWarnings = core.getInput(`allow-warnings`, { required: true }).trim()
+      const errorRegex = /^::error.+$/m
+      if (allowWarnings.toLowerCase() == "true" && !exc.stdout.match(errorRegex)) {
+        core.info(`golangci-lint found no errors`)
+      } else {
+        core.setFailed(`issues found`)
+      }
     } else {
       core.setFailed(`golangci-lint exit with code ${exc.code}`)
     }


### PR DESCRIPTION
There is an option to prevent `golangci-lint` from blocking a PR (by setting `--issues-exit-code 0`), but there currently is no way to configure the linter to only block on errors, and not on warnings (which seems like reasonable behavior, considering the two options are differentiated and supported by both `golangci-lint` and GitHub.

This PR adds the `allow-warnings: true` option, which, in the event that `golangci-lint` returns an exit code of `1`, causes `golangci-lint-action` to check the output, and if there are no `::error` notifications, return an exit code of `0`, allowing the PR or Push to proceed.

This allows annotating the code with warnings/suggestions that are non-blocking, but blocking in the event that there are errors.

It should be noted that this requires `golangci-lint` to be configured to exit with `1` on "Issues".  If `golangci-lint` does not exit with `1`, then the action assumes that it is supposed to pass, and does not modify the exit code.  That is to say it either exits with `0` if `golangci-lint` exits with `0`, or exits with `N`, where `N` is a positive exit code not equal to `1` (some other error).

The way this should be configured to exit "conditionally" is to set `--issues-exit-code 1`, and in `severity:` set your `default-severity:` and `rules:` accordingly.

This is tested and works accordingly. 