### PR TITLE
Extract and don't mangle User Args.

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6811,14 +6811,8 @@ function runLint(lintPath, patchPath) {
         }
         const userArgs = core.getInput(`args`);
         const addedArgs = [];
-        const userArgNames = new Set();
-        userArgs
-            .split(/\s/)
-            .map((arg) => arg.split(`=`)[0])
-            .filter((arg) => arg.startsWith(`-`))
-            .forEach((arg) => {
-            userArgNames.add(arg.replace(`-`, ``));
-        });
+        const userArgNamesRegex = /(?<=(^|\s)-+\b)([^\s=]+)(?==)/ig;
+        const userArgNames = new Set(userArgs.match(userArgNamesRegex));
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6811,8 +6811,12 @@ function runLint(lintPath, patchPath) {
         }
         const userArgs = core.getInput(`args`);
         const addedArgs = [];
-        const userArgNamesRegex = /(?<=(^|\s)-+\b)([^\s=]+)(?==)/ig;
-        const userArgNames = new Set(userArgs.match(userArgNamesRegex));
+        const userArgNames = new Set(userArgs
+            .trim()
+            .split(/\s+/)
+            .map((arg) => arg.split(`=`)[0])
+            .filter((arg) => arg.startsWith(`-`))
+            .map((arg) => arg.replace(/^-+/, ``)));
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6821,8 +6821,12 @@ function runLint(lintPath, patchPath) {
         }
         const userArgs = core.getInput(`args`);
         const addedArgs = [];
-        const userArgNamesRegex = /(?<=(^|\s)-+\b)([^\s=]+)(?==)/ig;
-        const userArgNames = new Set(userArgs.match(userArgNamesRegex));
+        const userArgNames = new Set(userArgs
+            .trim()
+            .split(/\s+/)
+            .map((arg) => arg.split(`=`)[0])
+            .filter((arg) => arg.startsWith(`-`))
+            .map((arg) => arg.replace(/^-+/, ``)));
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6821,14 +6821,8 @@ function runLint(lintPath, patchPath) {
         }
         const userArgs = core.getInput(`args`);
         const addedArgs = [];
-        const userArgNames = new Set();
-        userArgs
-            .split(/\s/)
-            .map((arg) => arg.split(`=`)[0])
-            .filter((arg) => arg.startsWith(`-`))
-            .forEach((arg) => {
-            userArgNames.add(arg.replace(`-`, ``));
-        });
+        const userArgNamesRegex = /(?<=(^|\s)-+\b)([^\s=]+)(?==)/ig;
+        const userArgNames = new Set(userArgs.match(userArgNamesRegex));
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }

--- a/src/run.ts
+++ b/src/run.ts
@@ -121,9 +121,14 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   const userArgs = core.getInput(`args`)
   const addedArgs: string[] = []
 
-  const userArgNamesRegex = /(?<=(^|\s)-+\b)([^\s=]+)(?==)/ig
-  const userArgNames = new Set<string>(userArgs.match(userArgNamesRegex))
-
+  const userArgNames = new Set<string>(
+    userArgs
+      .trim()
+      .split(/\s+/)
+      .map((arg) => arg.split(`=`)[0])
+      .filter((arg) => arg.startsWith(`-`))
+      .map((arg) => arg.replace(/^-+/, ``))
+  )
   if (userArgNames.has(`out-format`)) {
     throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`)
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -121,14 +121,8 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   const userArgs = core.getInput(`args`)
   const addedArgs: string[] = []
 
-  const userArgNames = new Set<string>()
-  userArgs
-    .split(/\s/)
-    .map((arg) => arg.split(`=`)[0])
-    .filter((arg) => arg.startsWith(`-`))
-    .forEach((arg) => {
-      userArgNames.add(arg.replace(`-`, ``))
-    })
+  const userArgNamesRegex = /(?<=(^|\s)-+\b)([^\s=]+)(?==)/ig
+  const userArgNames = new Set<string>(userArgs.match(userArgNamesRegex))
 
   if (userArgNames.has(`out-format`)) {
     throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`)


### PR DESCRIPTION
The current implementation mangles the contents of `userArgsNames` and prevents the successful checks that follow (preventing setting `out-format` and any of the `new-` parameters.  This fix extracts the names with a regex without mangling them.  The original iterative extraction looked creative and mildly elegant, but in testing, expanding it to not mangle the names made it less elegant, so using a `regex` and doing it in one go without iterating the array seemed like a simpler and more straight-forward approach.

Resolves: #199

**Note:** It looks like this bug has been in here for about 10 months (https://github.com/golangci/golangci-lint-action/commit/10cbc929b3868f44d02dc99a3368f81237ca356a), fixing this may break existing deployments.  Especially considering how I just suggested [using this bug as a use-case fix](https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-811922922).