### PR TITLE
Migrating to json data handeling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "if set to true then the action don't cache or restore ~/.cache/go-build."
     default: false
     required: true
+  failure-level:
+    description: "lowest issue severity to continue failing on (if golangci-lint exits with exit code 1), defaults to 'notice', may be: 'notice' | 'warning' | 'failure'"
+    default: "notice"
+    required: false
 runs:
   using: "node12"
   main: "dist/run/index.js"

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ inputs:
     required: false
 runs:
   using: "node12"
+  pre: "dist/pre/index.js"
   main: "dist/run/index.js"
   post: "dist/post_run/index.js"
 branding:

--- a/dist/matchers-golangci-lint-action.json
+++ b/dist/matchers-golangci-lint-action.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "golangci-lint-action",
+            "pattern": [
+                {
+                    "regexp": "^\\s*(\\.{0,2}[\\/\\\\].+\\.go):(?:(\\d+):(\\d+):)? (.*)",
+                    "severity": 1,
+                    "file": 2,
+                    "line": 3,
+                    "column": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -42,6 +42,8 @@ module.exports =
 /******/ 		// Load entry module and return exports
 /******/ 		return __webpack_require__(909);
 /******/ 	};
+/******/ 	// initialize runtime
+/******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// run startup
 /******/ 	return startup();
@@ -6703,10 +6705,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.postRun = exports.run = void 0;
 const core = __importStar(__webpack_require__(470));
 const github = __importStar(__webpack_require__(469));
+const ansi_styles_1 = __importDefault(__webpack_require__(663));
 const child_process_1 = __webpack_require__(129);
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
@@ -6794,6 +6800,159 @@ function prepareEnv() {
         return { lintPath, patchPath };
     });
 }
+var LintSeverity;
+(function (LintSeverity) {
+    LintSeverity[LintSeverity["notice"] = 0] = "notice";
+    LintSeverity[LintSeverity["warning"] = 1] = "warning";
+    LintSeverity[LintSeverity["failure"] = 2] = "failure";
+})(LintSeverity || (LintSeverity = {}));
+const DefaultFailureSeverity = LintSeverity.notice;
+const parseOutput = (json) => {
+    const severityMap = {
+        info: `notice`,
+        notice: `notice`,
+        minor: `warning`,
+        warning: `warning`,
+        error: `failure`,
+        major: `failure`,
+        critical: `failure`,
+        blocker: `failure`,
+        failure: `failure`,
+    };
+    const lintOutput = JSON.parse(json);
+    if (!lintOutput.Report) {
+        throw `golangci-lint returned invalid json`;
+    }
+    if (lintOutput.Issues.length) {
+        lintOutput.Issues = lintOutput.Issues.filter((issue) => issue.Severity !== `ignore`).map((issue) => {
+            const Severity = issue.Severity.toLowerCase();
+            issue.Severity = severityMap[`${Severity}`] ? severityMap[`${Severity}`] : `failure`;
+            return issue;
+        });
+    }
+    return lintOutput;
+};
+const logLintIssues = (issues) => {
+    issues.forEach((issue) => {
+        let header = `${ansi_styles_1.default.red.open}${ansi_styles_1.default.bold.open}Lint Error:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.red.close}`;
+        if (issue.Severity === `warning`) {
+            header = `${ansi_styles_1.default.yellow.open}${ansi_styles_1.default.bold.open}Lint Warning:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.yellow.close}`;
+        }
+        else if (issue.Severity === `notice`) {
+            header = `${ansi_styles_1.default.cyan.open}${ansi_styles_1.default.bold.open}Lint Notice:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.cyan.close}`;
+        }
+        let pos = `${issue.Pos.Filename}:${issue.Pos.Line}`;
+        if (issue.LineRange !== undefined) {
+            pos += `-${issue.LineRange.To}`;
+        }
+        else if (issue.Pos.Column) {
+            pos += `:${issue.Pos.Column}`;
+        }
+        core.info(`${header} ${pos} - ${issue.Text} (${issue.FromLinter})`);
+    });
+};
+function annotateLintIssues(issues) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!issues.length) {
+            return;
+        }
+        const ctx = github.context;
+        const ref = ctx.payload.after;
+        const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
+        const checkRunsPromise = octokit.checks
+            .listForRef(Object.assign(Object.assign({}, ctx.repo), { ref, status: "in_progress" }))
+            .catch((e) => {
+            throw `Error getting Check Run Data: ${e}`;
+        });
+        const chunkSize = 50;
+        const issueCounts = {
+            notice: 0,
+            warning: 0,
+            failure: 0,
+        };
+        const githubAnnotations = issues.map((issue) => {
+            // If/when we transition to comments, we would build the request structure here
+            const annotation = {
+                path: issue.Pos.Filename,
+                start_line: issue.Pos.Line,
+                end_line: issue.Pos.Line,
+                title: issue.FromLinter,
+                message: issue.Text,
+                annotation_level: issue.Severity,
+            };
+            issueCounts[issue.Severity]++;
+            if (issue.LineRange !== undefined) {
+                annotation.end_line = issue.LineRange.To;
+            }
+            else if (issue.Pos.Column) {
+                annotation.start_column = issue.Pos.Column;
+                annotation.end_column = issue.Pos.Column;
+            }
+            if (issue.Replacement !== null) {
+                let replacement = ``;
+                if (issue.Replacement.Inline) {
+                    replacement =
+                        issue.SourceLines[0].slice(0, issue.Replacement.Inline.StartCol) +
+                            issue.Replacement.Inline.NewString +
+                            issue.SourceLines[0].slice(issue.Replacement.Inline.StartCol + issue.Replacement.Inline.Length);
+                }
+                else if (issue.Replacement.NewLines) {
+                    replacement = issue.Replacement.NewLines.join("\n");
+                }
+                annotation.raw_details = "```suggestion\n" + replacement + "\n```";
+            }
+            return annotation;
+        });
+        let checkRun;
+        const { data: checkRunsResponse } = yield checkRunsPromise;
+        if (checkRunsResponse.check_runs.length === 0) {
+            throw `octokit.checks.listForRef(${ref}) returned no results`;
+        }
+        else {
+            checkRun = checkRunsResponse.check_runs.find((run) => run.name.includes(`Lint`));
+        }
+        if (!(checkRun === null || checkRun === void 0 ? void 0 : checkRun.id)) {
+            throw `Could not find current check run`;
+        }
+        const title = (_a = checkRun.output.title) !== null && _a !== void 0 ? _a : `GolangCI-Lint`;
+        const summary = `There are {issueCounts.failure} failures, {issueCounts.wairning} warnings, and {issueCounts.notice} notices.`;
+        Array.from({ length: Math.ceil(githubAnnotations.length / chunkSize) }, (v, i) => githubAnnotations.slice(i * chunkSize, i * chunkSize + chunkSize)).forEach((annotations) => {
+            octokit.checks
+                .update(Object.assign(Object.assign({}, ctx.repo), { check_run_id: checkRun === null || checkRun === void 0 ? void 0 : checkRun.id, output: {
+                    title,
+                    summary,
+                    annotations,
+                } }))
+                .catch((e) => {
+                throw `Error patching Check Run Data (annotations): ${e}`;
+            });
+        });
+    });
+}
+const hasFailingIssues = (issues) => {
+    // If the user input is not a valid Severity Level, this will be -1, and any issue will fail
+    const userFailureSeverity = core.getInput(`failure-severity`).toLowerCase();
+    let failureSeverity = DefaultFailureSeverity;
+    if (userFailureSeverity) {
+        failureSeverity = Object.values(LintSeverity).indexOf(userFailureSeverity);
+    }
+    if (failureSeverity < 0) {
+        core.info(`::warning::failure-severity must be one of (${Object.keys(LintSeverity).join(" | ")}). "${userFailureSeverity}" not supported, using default (${LintSeverity[DefaultFailureSeverity]})`);
+        failureSeverity = DefaultFailureSeverity;
+    }
+    if (issues.length) {
+        if (failureSeverity <= 0) {
+            return true;
+        }
+        for (const issue of issues) {
+            if (failureSeverity <= LintSeverity[issue.Severity]) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
 const printOutput = (res) => {
     if (res.stdout) {
         core.info(res.stdout);
@@ -6802,6 +6961,60 @@ const printOutput = (res) => {
         core.info(res.stderr);
     }
 };
+function printLintOutput(res) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        let lintOutput;
+        const exit_code = (_a = res.code) !== null && _a !== void 0 ? _a : 0;
+        try {
+            try {
+                if (res.stdout) {
+                    // This object contains other information, such as errors and the active linters
+                    // TODO: Should we do something with that data?
+                    lintOutput = parseOutput(res.stdout);
+                    if (lintOutput.Issues.length) {
+                        logLintIssues(lintOutput.Issues);
+                        // We can only Annotate (or Comment) on Push or Pull Request
+                        switch (github.context.eventName) {
+                            case `pull_request`:
+                            // TODO: When we are ready to handle these as Comments, instead of Annotations, we would place that logic here
+                            /* falls through */
+                            case `push`:
+                                yield annotateLintIssues(lintOutput.Issues);
+                                break;
+                            default:
+                                // At this time, other events are not supported
+                                break;
+                        }
+                    }
+                }
+            }
+            catch (e) {
+                throw `there was an error processing golangci-lint output: ${e}`;
+            }
+            if (res.stderr) {
+                core.info(res.stderr);
+            }
+            if (exit_code === 1) {
+                if (lintOutput) {
+                    if (hasFailingIssues(lintOutput.Issues)) {
+                        throw `issues found`;
+                    }
+                }
+                else {
+                    throw `unexpected state, golangci-lint exited with 1, but provided no lint output`;
+                }
+            }
+            else if (exit_code > 1) {
+                throw `golangci-lint exit with code ${exit_code}`;
+            }
+        }
+        catch (e) {
+            return core.setFailed(`${e}`);
+        }
+        return core.info(`golangci-lint found no blocking issues`);
+    });
+}
 function runLint(lintPath, patchPath) {
     return __awaiter(this, void 0, void 0, function* () {
         const debug = core.getInput(`debug`);
@@ -6822,7 +7035,7 @@ function runLint(lintPath, patchPath) {
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }
-        addedArgs.push(`--out-format=github-actions`);
+        addedArgs.push(`--out-format=json`);
         if (patchPath) {
             if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
                 throw new Error(`please, don't specify manually --new* args when requesting only new issues`);
@@ -6852,19 +7065,12 @@ function runLint(lintPath, patchPath) {
         const startedAt = Date.now();
         try {
             const res = yield execShellCommand(cmd, cmdArgs);
-            printOutput(res);
-            core.info(`golangci-lint found no issues`);
+            yield printLintOutput(res);
         }
         catch (exc) {
             // This logging passes issues to GitHub annotations but comments can be more convenient for some users.
             // TODO: support reviewdog or leaving comments by GitHub API.
-            printOutput(exc);
-            if (exc.code === 1) {
-                core.setFailed(`issues found`);
-            }
-            else {
-                core.setFailed(`golangci-lint exit with code ${exc.code}`);
-            }
+            yield printLintOutput(exc);
         }
         core.info(`Ran golangci-lint in ${Date.now() - startedAt}ms`);
     });
@@ -8814,7 +9020,109 @@ exports.downloadCacheStorageSDK = downloadCacheStorageSDK;
 /***/ }),
 /* 258 */,
 /* 259 */,
-/* 260 */,
+/* 260 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const conversions = __webpack_require__(600);
+
+/*
+	This function routes a model to all other models.
+
+	all functions that are routed have a property `.conversion` attached
+	to the returned synthetic function. This property is an array
+	of strings, each with the steps in between the 'from' and 'to'
+	color models (inclusive).
+
+	conversions that are not possible simply are not included.
+*/
+
+function buildGraph() {
+	const graph = {};
+	// https://jsperf.com/object-keys-vs-for-in-with-closure/3
+	const models = Object.keys(conversions);
+
+	for (let len = models.length, i = 0; i < len; i++) {
+		graph[models[i]] = {
+			// http://jsperf.com/1-vs-infinity
+			// micro-opt, but this is simple.
+			distance: -1,
+			parent: null
+		};
+	}
+
+	return graph;
+}
+
+// https://en.wikipedia.org/wiki/Breadth-first_search
+function deriveBFS(fromModel) {
+	const graph = buildGraph();
+	const queue = [fromModel]; // Unshift -> queue -> pop
+
+	graph[fromModel].distance = 0;
+
+	while (queue.length) {
+		const current = queue.pop();
+		const adjacents = Object.keys(conversions[current]);
+
+		for (let len = adjacents.length, i = 0; i < len; i++) {
+			const adjacent = adjacents[i];
+			const node = graph[adjacent];
+
+			if (node.distance === -1) {
+				node.distance = graph[current].distance + 1;
+				node.parent = current;
+				queue.unshift(adjacent);
+			}
+		}
+	}
+
+	return graph;
+}
+
+function link(from, to) {
+	return function (args) {
+		return to(from(args));
+	};
+}
+
+function wrapConversion(toModel, graph) {
+	const path = [graph[toModel].parent, toModel];
+	let fn = conversions[graph[toModel].parent][toModel];
+
+	let cur = graph[toModel].parent;
+	while (graph[cur].parent) {
+		path.unshift(graph[cur].parent);
+		fn = link(conversions[graph[cur].parent][cur], fn);
+		cur = graph[cur].parent;
+	}
+
+	fn.conversion = path;
+	return fn;
+}
+
+module.exports = function (fromModel) {
+	const graph = deriveBFS(fromModel);
+	const conversion = {};
+
+	const models = Object.keys(graph);
+	for (let len = models.length, i = 0; i < len; i++) {
+		const toModel = models[i];
+		const node = graph[toModel];
+
+		if (node.parent === null) {
+			// No possible conversion, or this node is the source model.
+			continue;
+		}
+
+		conversion[toModel] = wrapConversion(toModel, graph);
+	}
+
+	return conversion;
+};
+
+
+
+/***/ }),
 /* 261 */,
 /* 262 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -36614,7 +36922,393 @@ exports.endpoint = endpoint;
 /* 386 */,
 /* 387 */,
 /* 388 */,
-/* 389 */,
+/* 389 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+// Generated by CoffeeScript 1.12.7
+(function() {
+  "use strict";
+  var bom, defaults, events, isEmpty, processItem, processors, sax, setImmediate,
+    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+    extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+    hasProp = {}.hasOwnProperty;
+
+  sax = __webpack_require__(645);
+
+  events = __webpack_require__(614);
+
+  bom = __webpack_require__(210);
+
+  processors = __webpack_require__(350);
+
+  setImmediate = __webpack_require__(343).setImmediate;
+
+  defaults = __webpack_require__(791).defaults;
+
+  isEmpty = function(thing) {
+    return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
+  };
+
+  processItem = function(processors, item, key) {
+    var i, len, process;
+    for (i = 0, len = processors.length; i < len; i++) {
+      process = processors[i];
+      item = process(item, key);
+    }
+    return item;
+  };
+
+  exports.Parser = (function(superClass) {
+    extend(Parser, superClass);
+
+    function Parser(opts) {
+      this.parseStringPromise = bind(this.parseStringPromise, this);
+      this.parseString = bind(this.parseString, this);
+      this.reset = bind(this.reset, this);
+      this.assignOrPush = bind(this.assignOrPush, this);
+      this.processAsync = bind(this.processAsync, this);
+      var key, ref, value;
+      if (!(this instanceof exports.Parser)) {
+        return new exports.Parser(opts);
+      }
+      this.options = {};
+      ref = defaults["0.2"];
+      for (key in ref) {
+        if (!hasProp.call(ref, key)) continue;
+        value = ref[key];
+        this.options[key] = value;
+      }
+      for (key in opts) {
+        if (!hasProp.call(opts, key)) continue;
+        value = opts[key];
+        this.options[key] = value;
+      }
+      if (this.options.xmlns) {
+        this.options.xmlnskey = this.options.attrkey + "ns";
+      }
+      if (this.options.normalizeTags) {
+        if (!this.options.tagNameProcessors) {
+          this.options.tagNameProcessors = [];
+        }
+        this.options.tagNameProcessors.unshift(processors.normalize);
+      }
+      this.reset();
+    }
+
+    Parser.prototype.processAsync = function() {
+      var chunk, err;
+      try {
+        if (this.remaining.length <= this.options.chunkSize) {
+          chunk = this.remaining;
+          this.remaining = '';
+          this.saxParser = this.saxParser.write(chunk);
+          return this.saxParser.close();
+        } else {
+          chunk = this.remaining.substr(0, this.options.chunkSize);
+          this.remaining = this.remaining.substr(this.options.chunkSize, this.remaining.length);
+          this.saxParser = this.saxParser.write(chunk);
+          return setImmediate(this.processAsync);
+        }
+      } catch (error1) {
+        err = error1;
+        if (!this.saxParser.errThrown) {
+          this.saxParser.errThrown = true;
+          return this.emit(err);
+        }
+      }
+    };
+
+    Parser.prototype.assignOrPush = function(obj, key, newValue) {
+      if (!(key in obj)) {
+        if (!this.options.explicitArray) {
+          return obj[key] = newValue;
+        } else {
+          return obj[key] = [newValue];
+        }
+      } else {
+        if (!(obj[key] instanceof Array)) {
+          obj[key] = [obj[key]];
+        }
+        return obj[key].push(newValue);
+      }
+    };
+
+    Parser.prototype.reset = function() {
+      var attrkey, charkey, ontext, stack;
+      this.removeAllListeners();
+      this.saxParser = sax.parser(this.options.strict, {
+        trim: false,
+        normalize: false,
+        xmlns: this.options.xmlns
+      });
+      this.saxParser.errThrown = false;
+      this.saxParser.onerror = (function(_this) {
+        return function(error) {
+          _this.saxParser.resume();
+          if (!_this.saxParser.errThrown) {
+            _this.saxParser.errThrown = true;
+            return _this.emit("error", error);
+          }
+        };
+      })(this);
+      this.saxParser.onend = (function(_this) {
+        return function() {
+          if (!_this.saxParser.ended) {
+            _this.saxParser.ended = true;
+            return _this.emit("end", _this.resultObject);
+          }
+        };
+      })(this);
+      this.saxParser.ended = false;
+      this.EXPLICIT_CHARKEY = this.options.explicitCharkey;
+      this.resultObject = null;
+      stack = [];
+      attrkey = this.options.attrkey;
+      charkey = this.options.charkey;
+      this.saxParser.onopentag = (function(_this) {
+        return function(node) {
+          var key, newValue, obj, processedKey, ref;
+          obj = {};
+          obj[charkey] = "";
+          if (!_this.options.ignoreAttrs) {
+            ref = node.attributes;
+            for (key in ref) {
+              if (!hasProp.call(ref, key)) continue;
+              if (!(attrkey in obj) && !_this.options.mergeAttrs) {
+                obj[attrkey] = {};
+              }
+              newValue = _this.options.attrValueProcessors ? processItem(_this.options.attrValueProcessors, node.attributes[key], key) : node.attributes[key];
+              processedKey = _this.options.attrNameProcessors ? processItem(_this.options.attrNameProcessors, key) : key;
+              if (_this.options.mergeAttrs) {
+                _this.assignOrPush(obj, processedKey, newValue);
+              } else {
+                obj[attrkey][processedKey] = newValue;
+              }
+            }
+          }
+          obj["#name"] = _this.options.tagNameProcessors ? processItem(_this.options.tagNameProcessors, node.name) : node.name;
+          if (_this.options.xmlns) {
+            obj[_this.options.xmlnskey] = {
+              uri: node.uri,
+              local: node.local
+            };
+          }
+          return stack.push(obj);
+        };
+      })(this);
+      this.saxParser.onclosetag = (function(_this) {
+        return function() {
+          var cdata, emptyStr, key, node, nodeName, obj, objClone, old, s, xpath;
+          obj = stack.pop();
+          nodeName = obj["#name"];
+          if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
+            delete obj["#name"];
+          }
+          if (obj.cdata === true) {
+            cdata = obj.cdata;
+            delete obj.cdata;
+          }
+          s = stack[stack.length - 1];
+          if (obj[charkey].match(/^\s*$/) && !cdata) {
+            emptyStr = obj[charkey];
+            delete obj[charkey];
+          } else {
+            if (_this.options.trim) {
+              obj[charkey] = obj[charkey].trim();
+            }
+            if (_this.options.normalize) {
+              obj[charkey] = obj[charkey].replace(/\s{2,}/g, " ").trim();
+            }
+            obj[charkey] = _this.options.valueProcessors ? processItem(_this.options.valueProcessors, obj[charkey], nodeName) : obj[charkey];
+            if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
+              obj = obj[charkey];
+            }
+          }
+          if (isEmpty(obj)) {
+            obj = _this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr;
+          }
+          if (_this.options.validator != null) {
+            xpath = "/" + ((function() {
+              var i, len, results;
+              results = [];
+              for (i = 0, len = stack.length; i < len; i++) {
+                node = stack[i];
+                results.push(node["#name"]);
+              }
+              return results;
+            })()).concat(nodeName).join("/");
+            (function() {
+              var err;
+              try {
+                return obj = _this.options.validator(xpath, s && s[nodeName], obj);
+              } catch (error1) {
+                err = error1;
+                return _this.emit("error", err);
+              }
+            })();
+          }
+          if (_this.options.explicitChildren && !_this.options.mergeAttrs && typeof obj === 'object') {
+            if (!_this.options.preserveChildrenOrder) {
+              node = {};
+              if (_this.options.attrkey in obj) {
+                node[_this.options.attrkey] = obj[_this.options.attrkey];
+                delete obj[_this.options.attrkey];
+              }
+              if (!_this.options.charsAsChildren && _this.options.charkey in obj) {
+                node[_this.options.charkey] = obj[_this.options.charkey];
+                delete obj[_this.options.charkey];
+              }
+              if (Object.getOwnPropertyNames(obj).length > 0) {
+                node[_this.options.childkey] = obj;
+              }
+              obj = node;
+            } else if (s) {
+              s[_this.options.childkey] = s[_this.options.childkey] || [];
+              objClone = {};
+              for (key in obj) {
+                if (!hasProp.call(obj, key)) continue;
+                objClone[key] = obj[key];
+              }
+              s[_this.options.childkey].push(objClone);
+              delete obj["#name"];
+              if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
+                obj = obj[charkey];
+              }
+            }
+          }
+          if (stack.length > 0) {
+            return _this.assignOrPush(s, nodeName, obj);
+          } else {
+            if (_this.options.explicitRoot) {
+              old = obj;
+              obj = {};
+              obj[nodeName] = old;
+            }
+            _this.resultObject = obj;
+            _this.saxParser.ended = true;
+            return _this.emit("end", _this.resultObject);
+          }
+        };
+      })(this);
+      ontext = (function(_this) {
+        return function(text) {
+          var charChild, s;
+          s = stack[stack.length - 1];
+          if (s) {
+            s[charkey] += text;
+            if (_this.options.explicitChildren && _this.options.preserveChildrenOrder && _this.options.charsAsChildren && (_this.options.includeWhiteChars || text.replace(/\\n/g, '').trim() !== '')) {
+              s[_this.options.childkey] = s[_this.options.childkey] || [];
+              charChild = {
+                '#name': '__text__'
+              };
+              charChild[charkey] = text;
+              if (_this.options.normalize) {
+                charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, " ").trim();
+              }
+              s[_this.options.childkey].push(charChild);
+            }
+            return s;
+          }
+        };
+      })(this);
+      this.saxParser.ontext = ontext;
+      return this.saxParser.oncdata = (function(_this) {
+        return function(text) {
+          var s;
+          s = ontext(text);
+          if (s) {
+            return s.cdata = true;
+          }
+        };
+      })(this);
+    };
+
+    Parser.prototype.parseString = function(str, cb) {
+      var err;
+      if ((cb != null) && typeof cb === "function") {
+        this.on("end", function(result) {
+          this.reset();
+          return cb(null, result);
+        });
+        this.on("error", function(err) {
+          this.reset();
+          return cb(err);
+        });
+      }
+      try {
+        str = str.toString();
+        if (str.trim() === '') {
+          this.emit("end", null);
+          return true;
+        }
+        str = bom.stripBOM(str);
+        if (this.options.async) {
+          this.remaining = str;
+          setImmediate(this.processAsync);
+          return this.saxParser;
+        }
+        return this.saxParser.write(str).close();
+      } catch (error1) {
+        err = error1;
+        if (!(this.saxParser.errThrown || this.saxParser.ended)) {
+          this.emit('error', err);
+          return this.saxParser.errThrown = true;
+        } else if (this.saxParser.ended) {
+          throw err;
+        }
+      }
+    };
+
+    Parser.prototype.parseStringPromise = function(str) {
+      return new Promise((function(_this) {
+        return function(resolve, reject) {
+          return _this.parseString(str, function(err, value) {
+            if (err) {
+              return reject(err);
+            } else {
+              return resolve(value);
+            }
+          });
+        };
+      })(this));
+    };
+
+    return Parser;
+
+  })(events);
+
+  exports.parseString = function(str, a, b) {
+    var cb, options, parser;
+    if (b != null) {
+      if (typeof b === 'function') {
+        cb = b;
+      }
+      if (typeof a === 'object') {
+        options = a;
+      }
+    } else {
+      if (typeof a === 'function') {
+        cb = a;
+      }
+      options = {};
+    }
+    parser = new exports.Parser(options);
+    return parser.parseString(str, cb);
+  };
+
+  exports.parseStringPromise = function(str, a) {
+    var options, parser;
+    if (typeof a === 'object') {
+      options = a;
+    }
+    parser = new exports.Parser(options);
+    return parser.parseStringPromise(str);
+  };
+
+}).call(this);
+
+
+/***/ }),
 /* 390 */,
 /* 391 */,
 /* 392 */,
@@ -45901,7 +46595,93 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 589 */,
 /* 590 */,
 /* 591 */,
-/* 592 */,
+/* 592 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const conversions = __webpack_require__(600);
+const route = __webpack_require__(260);
+
+const convert = {};
+
+const models = Object.keys(conversions);
+
+function wrapRaw(fn) {
+	const wrappedFn = function (...args) {
+		const arg0 = args[0];
+		if (arg0 === undefined || arg0 === null) {
+			return arg0;
+		}
+
+		if (arg0.length > 1) {
+			args = arg0;
+		}
+
+		return fn(args);
+	};
+
+	// Preserve .conversion property if there is one
+	if ('conversion' in fn) {
+		wrappedFn.conversion = fn.conversion;
+	}
+
+	return wrappedFn;
+}
+
+function wrapRounded(fn) {
+	const wrappedFn = function (...args) {
+		const arg0 = args[0];
+
+		if (arg0 === undefined || arg0 === null) {
+			return arg0;
+		}
+
+		if (arg0.length > 1) {
+			args = arg0;
+		}
+
+		const result = fn(args);
+
+		// We're assuming the result is an array here.
+		// see notice in conversions.js; don't use box types
+		// in conversion functions.
+		if (typeof result === 'object') {
+			for (let len = result.length, i = 0; i < len; i++) {
+				result[i] = Math.round(result[i]);
+			}
+		}
+
+		return result;
+	};
+
+	// Preserve .conversion property if there is one
+	if ('conversion' in fn) {
+		wrappedFn.conversion = fn.conversion;
+	}
+
+	return wrappedFn;
+}
+
+models.forEach(fromModel => {
+	convert[fromModel] = {};
+
+	Object.defineProperty(convert[fromModel], 'channels', {value: conversions[fromModel].channels});
+	Object.defineProperty(convert[fromModel], 'labels', {value: conversions[fromModel].labels});
+
+	const routes = route(fromModel);
+	const routeModels = Object.keys(routes);
+
+	routeModels.forEach(toModel => {
+		const fn = routes[toModel];
+
+		convert[fromModel][toModel] = wrapRounded(fn);
+		convert[fromModel][toModel].raw = wrapRaw(fn);
+	});
+});
+
+module.exports = convert;
+
+
+/***/ }),
 /* 593 */,
 /* 594 */,
 /* 595 */,
@@ -45995,7 +46775,851 @@ exports.partialMatch = partialMatch;
 /***/ }),
 /* 598 */,
 /* 599 */,
-/* 600 */,
+/* 600 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+/* MIT license */
+/* eslint-disable no-mixed-operators */
+const cssKeywords = __webpack_require__(885);
+
+// NOTE: conversions should only return primitive values (i.e. arrays, or
+//       values that give correct `typeof` results).
+//       do not use box values types (i.e. Number(), String(), etc.)
+
+const reverseKeywords = {};
+for (const key of Object.keys(cssKeywords)) {
+	reverseKeywords[cssKeywords[key]] = key;
+}
+
+const convert = {
+	rgb: {channels: 3, labels: 'rgb'},
+	hsl: {channels: 3, labels: 'hsl'},
+	hsv: {channels: 3, labels: 'hsv'},
+	hwb: {channels: 3, labels: 'hwb'},
+	cmyk: {channels: 4, labels: 'cmyk'},
+	xyz: {channels: 3, labels: 'xyz'},
+	lab: {channels: 3, labels: 'lab'},
+	lch: {channels: 3, labels: 'lch'},
+	hex: {channels: 1, labels: ['hex']},
+	keyword: {channels: 1, labels: ['keyword']},
+	ansi16: {channels: 1, labels: ['ansi16']},
+	ansi256: {channels: 1, labels: ['ansi256']},
+	hcg: {channels: 3, labels: ['h', 'c', 'g']},
+	apple: {channels: 3, labels: ['r16', 'g16', 'b16']},
+	gray: {channels: 1, labels: ['gray']}
+};
+
+module.exports = convert;
+
+// Hide .channels and .labels properties
+for (const model of Object.keys(convert)) {
+	if (!('channels' in convert[model])) {
+		throw new Error('missing channels property: ' + model);
+	}
+
+	if (!('labels' in convert[model])) {
+		throw new Error('missing channel labels property: ' + model);
+	}
+
+	if (convert[model].labels.length !== convert[model].channels) {
+		throw new Error('channel and label counts mismatch: ' + model);
+	}
+
+	const {channels, labels} = convert[model];
+	delete convert[model].channels;
+	delete convert[model].labels;
+	Object.defineProperty(convert[model], 'channels', {value: channels});
+	Object.defineProperty(convert[model], 'labels', {value: labels});
+}
+
+convert.rgb.hsl = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const min = Math.min(r, g, b);
+	const max = Math.max(r, g, b);
+	const delta = max - min;
+	let h;
+	let s;
+
+	if (max === min) {
+		h = 0;
+	} else if (r === max) {
+		h = (g - b) / delta;
+	} else if (g === max) {
+		h = 2 + (b - r) / delta;
+	} else if (b === max) {
+		h = 4 + (r - g) / delta;
+	}
+
+	h = Math.min(h * 60, 360);
+
+	if (h < 0) {
+		h += 360;
+	}
+
+	const l = (min + max) / 2;
+
+	if (max === min) {
+		s = 0;
+	} else if (l <= 0.5) {
+		s = delta / (max + min);
+	} else {
+		s = delta / (2 - max - min);
+	}
+
+	return [h, s * 100, l * 100];
+};
+
+convert.rgb.hsv = function (rgb) {
+	let rdif;
+	let gdif;
+	let bdif;
+	let h;
+	let s;
+
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const v = Math.max(r, g, b);
+	const diff = v - Math.min(r, g, b);
+	const diffc = function (c) {
+		return (v - c) / 6 / diff + 1 / 2;
+	};
+
+	if (diff === 0) {
+		h = 0;
+		s = 0;
+	} else {
+		s = diff / v;
+		rdif = diffc(r);
+		gdif = diffc(g);
+		bdif = diffc(b);
+
+		if (r === v) {
+			h = bdif - gdif;
+		} else if (g === v) {
+			h = (1 / 3) + rdif - bdif;
+		} else if (b === v) {
+			h = (2 / 3) + gdif - rdif;
+		}
+
+		if (h < 0) {
+			h += 1;
+		} else if (h > 1) {
+			h -= 1;
+		}
+	}
+
+	return [
+		h * 360,
+		s * 100,
+		v * 100
+	];
+};
+
+convert.rgb.hwb = function (rgb) {
+	const r = rgb[0];
+	const g = rgb[1];
+	let b = rgb[2];
+	const h = convert.rgb.hsl(rgb)[0];
+	const w = 1 / 255 * Math.min(r, Math.min(g, b));
+
+	b = 1 - 1 / 255 * Math.max(r, Math.max(g, b));
+
+	return [h, w * 100, b * 100];
+};
+
+convert.rgb.cmyk = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+
+	const k = Math.min(1 - r, 1 - g, 1 - b);
+	const c = (1 - r - k) / (1 - k) || 0;
+	const m = (1 - g - k) / (1 - k) || 0;
+	const y = (1 - b - k) / (1 - k) || 0;
+
+	return [c * 100, m * 100, y * 100, k * 100];
+};
+
+function comparativeDistance(x, y) {
+	/*
+		See https://en.m.wikipedia.org/wiki/Euclidean_distance#Squared_Euclidean_distance
+	*/
+	return (
+		((x[0] - y[0]) ** 2) +
+		((x[1] - y[1]) ** 2) +
+		((x[2] - y[2]) ** 2)
+	);
+}
+
+convert.rgb.keyword = function (rgb) {
+	const reversed = reverseKeywords[rgb];
+	if (reversed) {
+		return reversed;
+	}
+
+	let currentClosestDistance = Infinity;
+	let currentClosestKeyword;
+
+	for (const keyword of Object.keys(cssKeywords)) {
+		const value = cssKeywords[keyword];
+
+		// Compute comparative distance
+		const distance = comparativeDistance(rgb, value);
+
+		// Check if its less, if so set as closest
+		if (distance < currentClosestDistance) {
+			currentClosestDistance = distance;
+			currentClosestKeyword = keyword;
+		}
+	}
+
+	return currentClosestKeyword;
+};
+
+convert.keyword.rgb = function (keyword) {
+	return cssKeywords[keyword];
+};
+
+convert.rgb.xyz = function (rgb) {
+	let r = rgb[0] / 255;
+	let g = rgb[1] / 255;
+	let b = rgb[2] / 255;
+
+	// Assume sRGB
+	r = r > 0.04045 ? (((r + 0.055) / 1.055) ** 2.4) : (r / 12.92);
+	g = g > 0.04045 ? (((g + 0.055) / 1.055) ** 2.4) : (g / 12.92);
+	b = b > 0.04045 ? (((b + 0.055) / 1.055) ** 2.4) : (b / 12.92);
+
+	const x = (r * 0.4124) + (g * 0.3576) + (b * 0.1805);
+	const y = (r * 0.2126) + (g * 0.7152) + (b * 0.0722);
+	const z = (r * 0.0193) + (g * 0.1192) + (b * 0.9505);
+
+	return [x * 100, y * 100, z * 100];
+};
+
+convert.rgb.lab = function (rgb) {
+	const xyz = convert.rgb.xyz(rgb);
+	let x = xyz[0];
+	let y = xyz[1];
+	let z = xyz[2];
+
+	x /= 95.047;
+	y /= 100;
+	z /= 108.883;
+
+	x = x > 0.008856 ? (x ** (1 / 3)) : (7.787 * x) + (16 / 116);
+	y = y > 0.008856 ? (y ** (1 / 3)) : (7.787 * y) + (16 / 116);
+	z = z > 0.008856 ? (z ** (1 / 3)) : (7.787 * z) + (16 / 116);
+
+	const l = (116 * y) - 16;
+	const a = 500 * (x - y);
+	const b = 200 * (y - z);
+
+	return [l, a, b];
+};
+
+convert.hsl.rgb = function (hsl) {
+	const h = hsl[0] / 360;
+	const s = hsl[1] / 100;
+	const l = hsl[2] / 100;
+	let t2;
+	let t3;
+	let val;
+
+	if (s === 0) {
+		val = l * 255;
+		return [val, val, val];
+	}
+
+	if (l < 0.5) {
+		t2 = l * (1 + s);
+	} else {
+		t2 = l + s - l * s;
+	}
+
+	const t1 = 2 * l - t2;
+
+	const rgb = [0, 0, 0];
+	for (let i = 0; i < 3; i++) {
+		t3 = h + 1 / 3 * -(i - 1);
+		if (t3 < 0) {
+			t3++;
+		}
+
+		if (t3 > 1) {
+			t3--;
+		}
+
+		if (6 * t3 < 1) {
+			val = t1 + (t2 - t1) * 6 * t3;
+		} else if (2 * t3 < 1) {
+			val = t2;
+		} else if (3 * t3 < 2) {
+			val = t1 + (t2 - t1) * (2 / 3 - t3) * 6;
+		} else {
+			val = t1;
+		}
+
+		rgb[i] = val * 255;
+	}
+
+	return rgb;
+};
+
+convert.hsl.hsv = function (hsl) {
+	const h = hsl[0];
+	let s = hsl[1] / 100;
+	let l = hsl[2] / 100;
+	let smin = s;
+	const lmin = Math.max(l, 0.01);
+
+	l *= 2;
+	s *= (l <= 1) ? l : 2 - l;
+	smin *= lmin <= 1 ? lmin : 2 - lmin;
+	const v = (l + s) / 2;
+	const sv = l === 0 ? (2 * smin) / (lmin + smin) : (2 * s) / (l + s);
+
+	return [h, sv * 100, v * 100];
+};
+
+convert.hsv.rgb = function (hsv) {
+	const h = hsv[0] / 60;
+	const s = hsv[1] / 100;
+	let v = hsv[2] / 100;
+	const hi = Math.floor(h) % 6;
+
+	const f = h - Math.floor(h);
+	const p = 255 * v * (1 - s);
+	const q = 255 * v * (1 - (s * f));
+	const t = 255 * v * (1 - (s * (1 - f)));
+	v *= 255;
+
+	switch (hi) {
+		case 0:
+			return [v, t, p];
+		case 1:
+			return [q, v, p];
+		case 2:
+			return [p, v, t];
+		case 3:
+			return [p, q, v];
+		case 4:
+			return [t, p, v];
+		case 5:
+			return [v, p, q];
+	}
+};
+
+convert.hsv.hsl = function (hsv) {
+	const h = hsv[0];
+	const s = hsv[1] / 100;
+	const v = hsv[2] / 100;
+	const vmin = Math.max(v, 0.01);
+	let sl;
+	let l;
+
+	l = (2 - s) * v;
+	const lmin = (2 - s) * vmin;
+	sl = s * vmin;
+	sl /= (lmin <= 1) ? lmin : 2 - lmin;
+	sl = sl || 0;
+	l /= 2;
+
+	return [h, sl * 100, l * 100];
+};
+
+// http://dev.w3.org/csswg/css-color/#hwb-to-rgb
+convert.hwb.rgb = function (hwb) {
+	const h = hwb[0] / 360;
+	let wh = hwb[1] / 100;
+	let bl = hwb[2] / 100;
+	const ratio = wh + bl;
+	let f;
+
+	// Wh + bl cant be > 1
+	if (ratio > 1) {
+		wh /= ratio;
+		bl /= ratio;
+	}
+
+	const i = Math.floor(6 * h);
+	const v = 1 - bl;
+	f = 6 * h - i;
+
+	if ((i & 0x01) !== 0) {
+		f = 1 - f;
+	}
+
+	const n = wh + f * (v - wh); // Linear interpolation
+
+	let r;
+	let g;
+	let b;
+	/* eslint-disable max-statements-per-line,no-multi-spaces */
+	switch (i) {
+		default:
+		case 6:
+		case 0: r = v;  g = n;  b = wh; break;
+		case 1: r = n;  g = v;  b = wh; break;
+		case 2: r = wh; g = v;  b = n; break;
+		case 3: r = wh; g = n;  b = v; break;
+		case 4: r = n;  g = wh; b = v; break;
+		case 5: r = v;  g = wh; b = n; break;
+	}
+	/* eslint-enable max-statements-per-line,no-multi-spaces */
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert.cmyk.rgb = function (cmyk) {
+	const c = cmyk[0] / 100;
+	const m = cmyk[1] / 100;
+	const y = cmyk[2] / 100;
+	const k = cmyk[3] / 100;
+
+	const r = 1 - Math.min(1, c * (1 - k) + k);
+	const g = 1 - Math.min(1, m * (1 - k) + k);
+	const b = 1 - Math.min(1, y * (1 - k) + k);
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert.xyz.rgb = function (xyz) {
+	const x = xyz[0] / 100;
+	const y = xyz[1] / 100;
+	const z = xyz[2] / 100;
+	let r;
+	let g;
+	let b;
+
+	r = (x * 3.2406) + (y * -1.5372) + (z * -0.4986);
+	g = (x * -0.9689) + (y * 1.8758) + (z * 0.0415);
+	b = (x * 0.0557) + (y * -0.2040) + (z * 1.0570);
+
+	// Assume sRGB
+	r = r > 0.0031308
+		? ((1.055 * (r ** (1.0 / 2.4))) - 0.055)
+		: r * 12.92;
+
+	g = g > 0.0031308
+		? ((1.055 * (g ** (1.0 / 2.4))) - 0.055)
+		: g * 12.92;
+
+	b = b > 0.0031308
+		? ((1.055 * (b ** (1.0 / 2.4))) - 0.055)
+		: b * 12.92;
+
+	r = Math.min(Math.max(0, r), 1);
+	g = Math.min(Math.max(0, g), 1);
+	b = Math.min(Math.max(0, b), 1);
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert.xyz.lab = function (xyz) {
+	let x = xyz[0];
+	let y = xyz[1];
+	let z = xyz[2];
+
+	x /= 95.047;
+	y /= 100;
+	z /= 108.883;
+
+	x = x > 0.008856 ? (x ** (1 / 3)) : (7.787 * x) + (16 / 116);
+	y = y > 0.008856 ? (y ** (1 / 3)) : (7.787 * y) + (16 / 116);
+	z = z > 0.008856 ? (z ** (1 / 3)) : (7.787 * z) + (16 / 116);
+
+	const l = (116 * y) - 16;
+	const a = 500 * (x - y);
+	const b = 200 * (y - z);
+
+	return [l, a, b];
+};
+
+convert.lab.xyz = function (lab) {
+	const l = lab[0];
+	const a = lab[1];
+	const b = lab[2];
+	let x;
+	let y;
+	let z;
+
+	y = (l + 16) / 116;
+	x = a / 500 + y;
+	z = y - b / 200;
+
+	const y2 = y ** 3;
+	const x2 = x ** 3;
+	const z2 = z ** 3;
+	y = y2 > 0.008856 ? y2 : (y - 16 / 116) / 7.787;
+	x = x2 > 0.008856 ? x2 : (x - 16 / 116) / 7.787;
+	z = z2 > 0.008856 ? z2 : (z - 16 / 116) / 7.787;
+
+	x *= 95.047;
+	y *= 100;
+	z *= 108.883;
+
+	return [x, y, z];
+};
+
+convert.lab.lch = function (lab) {
+	const l = lab[0];
+	const a = lab[1];
+	const b = lab[2];
+	let h;
+
+	const hr = Math.atan2(b, a);
+	h = hr * 360 / 2 / Math.PI;
+
+	if (h < 0) {
+		h += 360;
+	}
+
+	const c = Math.sqrt(a * a + b * b);
+
+	return [l, c, h];
+};
+
+convert.lch.lab = function (lch) {
+	const l = lch[0];
+	const c = lch[1];
+	const h = lch[2];
+
+	const hr = h / 360 * 2 * Math.PI;
+	const a = c * Math.cos(hr);
+	const b = c * Math.sin(hr);
+
+	return [l, a, b];
+};
+
+convert.rgb.ansi16 = function (args, saturation = null) {
+	const [r, g, b] = args;
+	let value = saturation === null ? convert.rgb.hsv(args)[2] : saturation; // Hsv -> ansi16 optimization
+
+	value = Math.round(value / 50);
+
+	if (value === 0) {
+		return 30;
+	}
+
+	let ansi = 30
+		+ ((Math.round(b / 255) << 2)
+		| (Math.round(g / 255) << 1)
+		| Math.round(r / 255));
+
+	if (value === 2) {
+		ansi += 60;
+	}
+
+	return ansi;
+};
+
+convert.hsv.ansi16 = function (args) {
+	// Optimization here; we already know the value and don't need to get
+	// it converted for us.
+	return convert.rgb.ansi16(convert.hsv.rgb(args), args[2]);
+};
+
+convert.rgb.ansi256 = function (args) {
+	const r = args[0];
+	const g = args[1];
+	const b = args[2];
+
+	// We use the extended greyscale palette here, with the exception of
+	// black and white. normal palette only has 4 greyscale shades.
+	if (r === g && g === b) {
+		if (r < 8) {
+			return 16;
+		}
+
+		if (r > 248) {
+			return 231;
+		}
+
+		return Math.round(((r - 8) / 247) * 24) + 232;
+	}
+
+	const ansi = 16
+		+ (36 * Math.round(r / 255 * 5))
+		+ (6 * Math.round(g / 255 * 5))
+		+ Math.round(b / 255 * 5);
+
+	return ansi;
+};
+
+convert.ansi16.rgb = function (args) {
+	let color = args % 10;
+
+	// Handle greyscale
+	if (color === 0 || color === 7) {
+		if (args > 50) {
+			color += 3.5;
+		}
+
+		color = color / 10.5 * 255;
+
+		return [color, color, color];
+	}
+
+	const mult = (~~(args > 50) + 1) * 0.5;
+	const r = ((color & 1) * mult) * 255;
+	const g = (((color >> 1) & 1) * mult) * 255;
+	const b = (((color >> 2) & 1) * mult) * 255;
+
+	return [r, g, b];
+};
+
+convert.ansi256.rgb = function (args) {
+	// Handle greyscale
+	if (args >= 232) {
+		const c = (args - 232) * 10 + 8;
+		return [c, c, c];
+	}
+
+	args -= 16;
+
+	let rem;
+	const r = Math.floor(args / 36) / 5 * 255;
+	const g = Math.floor((rem = args % 36) / 6) / 5 * 255;
+	const b = (rem % 6) / 5 * 255;
+
+	return [r, g, b];
+};
+
+convert.rgb.hex = function (args) {
+	const integer = ((Math.round(args[0]) & 0xFF) << 16)
+		+ ((Math.round(args[1]) & 0xFF) << 8)
+		+ (Math.round(args[2]) & 0xFF);
+
+	const string = integer.toString(16).toUpperCase();
+	return '000000'.substring(string.length) + string;
+};
+
+convert.hex.rgb = function (args) {
+	const match = args.toString(16).match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
+	if (!match) {
+		return [0, 0, 0];
+	}
+
+	let colorString = match[0];
+
+	if (match[0].length === 3) {
+		colorString = colorString.split('').map(char => {
+			return char + char;
+		}).join('');
+	}
+
+	const integer = parseInt(colorString, 16);
+	const r = (integer >> 16) & 0xFF;
+	const g = (integer >> 8) & 0xFF;
+	const b = integer & 0xFF;
+
+	return [r, g, b];
+};
+
+convert.rgb.hcg = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const max = Math.max(Math.max(r, g), b);
+	const min = Math.min(Math.min(r, g), b);
+	const chroma = (max - min);
+	let grayscale;
+	let hue;
+
+	if (chroma < 1) {
+		grayscale = min / (1 - chroma);
+	} else {
+		grayscale = 0;
+	}
+
+	if (chroma <= 0) {
+		hue = 0;
+	} else
+	if (max === r) {
+		hue = ((g - b) / chroma) % 6;
+	} else
+	if (max === g) {
+		hue = 2 + (b - r) / chroma;
+	} else {
+		hue = 4 + (r - g) / chroma;
+	}
+
+	hue /= 6;
+	hue %= 1;
+
+	return [hue * 360, chroma * 100, grayscale * 100];
+};
+
+convert.hsl.hcg = function (hsl) {
+	const s = hsl[1] / 100;
+	const l = hsl[2] / 100;
+
+	const c = l < 0.5 ? (2.0 * s * l) : (2.0 * s * (1.0 - l));
+
+	let f = 0;
+	if (c < 1.0) {
+		f = (l - 0.5 * c) / (1.0 - c);
+	}
+
+	return [hsl[0], c * 100, f * 100];
+};
+
+convert.hsv.hcg = function (hsv) {
+	const s = hsv[1] / 100;
+	const v = hsv[2] / 100;
+
+	const c = s * v;
+	let f = 0;
+
+	if (c < 1.0) {
+		f = (v - c) / (1 - c);
+	}
+
+	return [hsv[0], c * 100, f * 100];
+};
+
+convert.hcg.rgb = function (hcg) {
+	const h = hcg[0] / 360;
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	if (c === 0.0) {
+		return [g * 255, g * 255, g * 255];
+	}
+
+	const pure = [0, 0, 0];
+	const hi = (h % 1) * 6;
+	const v = hi % 1;
+	const w = 1 - v;
+	let mg = 0;
+
+	/* eslint-disable max-statements-per-line */
+	switch (Math.floor(hi)) {
+		case 0:
+			pure[0] = 1; pure[1] = v; pure[2] = 0; break;
+		case 1:
+			pure[0] = w; pure[1] = 1; pure[2] = 0; break;
+		case 2:
+			pure[0] = 0; pure[1] = 1; pure[2] = v; break;
+		case 3:
+			pure[0] = 0; pure[1] = w; pure[2] = 1; break;
+		case 4:
+			pure[0] = v; pure[1] = 0; pure[2] = 1; break;
+		default:
+			pure[0] = 1; pure[1] = 0; pure[2] = w;
+	}
+	/* eslint-enable max-statements-per-line */
+
+	mg = (1.0 - c) * g;
+
+	return [
+		(c * pure[0] + mg) * 255,
+		(c * pure[1] + mg) * 255,
+		(c * pure[2] + mg) * 255
+	];
+};
+
+convert.hcg.hsv = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	const v = c + g * (1.0 - c);
+	let f = 0;
+
+	if (v > 0.0) {
+		f = c / v;
+	}
+
+	return [hcg[0], f * 100, v * 100];
+};
+
+convert.hcg.hsl = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	const l = g * (1.0 - c) + 0.5 * c;
+	let s = 0;
+
+	if (l > 0.0 && l < 0.5) {
+		s = c / (2 * l);
+	} else
+	if (l >= 0.5 && l < 1.0) {
+		s = c / (2 * (1 - l));
+	}
+
+	return [hcg[0], s * 100, l * 100];
+};
+
+convert.hcg.hwb = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+	const v = c + g * (1.0 - c);
+	return [hcg[0], (v - c) * 100, (1 - v) * 100];
+};
+
+convert.hwb.hcg = function (hwb) {
+	const w = hwb[1] / 100;
+	const b = hwb[2] / 100;
+	const v = 1 - b;
+	const c = v - w;
+	let g = 0;
+
+	if (c < 1) {
+		g = (v - c) / (1 - c);
+	}
+
+	return [hwb[0], c * 100, g * 100];
+};
+
+convert.apple.rgb = function (apple) {
+	return [(apple[0] / 65535) * 255, (apple[1] / 65535) * 255, (apple[2] / 65535) * 255];
+};
+
+convert.rgb.apple = function (rgb) {
+	return [(rgb[0] / 255) * 65535, (rgb[1] / 255) * 65535, (rgb[2] / 255) * 65535];
+};
+
+convert.gray.rgb = function (args) {
+	return [args[0] / 100 * 255, args[0] / 100 * 255, args[0] / 100 * 255];
+};
+
+convert.gray.hsl = function (args) {
+	return [0, 0, args[0]];
+};
+
+convert.gray.hsv = convert.gray.hsl;
+
+convert.gray.hwb = function (gray) {
+	return [0, 100, gray[0]];
+};
+
+convert.gray.cmyk = function (gray) {
+	return [0, 0, 0, gray[0]];
+};
+
+convert.gray.lab = function (gray) {
+	return [gray[0], 0, 0];
+};
+
+convert.gray.hex = function (gray) {
+	const val = Math.round(gray[0] / 100 * 255) & 0xFF;
+	const integer = (val << 16) + (val << 8) + val;
+
+	const string = integer.toString(16).toUpperCase();
+	return '000000'.substring(string.length) + string;
+};
+
+convert.rgb.gray = function (rgb) {
+	const val = (rgb[0] + rgb[1] + rgb[2]) / 3;
+	return [val / 255 * 100];
+};
+
+
+/***/ }),
 /* 601 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -49514,7 +51138,177 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 /***/ }),
 /* 662 */,
-/* 663 */,
+/* 663 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+/* module decorator */ module = __webpack_require__.nmd(module);
+
+
+const wrapAnsi16 = (fn, offset) => (...args) => {
+	const code = fn(...args);
+	return `\u001B[${code + offset}m`;
+};
+
+const wrapAnsi256 = (fn, offset) => (...args) => {
+	const code = fn(...args);
+	return `\u001B[${38 + offset};5;${code}m`;
+};
+
+const wrapAnsi16m = (fn, offset) => (...args) => {
+	const rgb = fn(...args);
+	return `\u001B[${38 + offset};2;${rgb[0]};${rgb[1]};${rgb[2]}m`;
+};
+
+const ansi2ansi = n => n;
+const rgb2rgb = (r, g, b) => [r, g, b];
+
+const setLazyProperty = (object, property, get) => {
+	Object.defineProperty(object, property, {
+		get: () => {
+			const value = get();
+
+			Object.defineProperty(object, property, {
+				value,
+				enumerable: true,
+				configurable: true
+			});
+
+			return value;
+		},
+		enumerable: true,
+		configurable: true
+	});
+};
+
+/** @type {typeof import('color-convert')} */
+let colorConvert;
+const makeDynamicStyles = (wrap, targetSpace, identity, isBackground) => {
+	if (colorConvert === undefined) {
+		colorConvert = __webpack_require__(592);
+	}
+
+	const offset = isBackground ? 10 : 0;
+	const styles = {};
+
+	for (const [sourceSpace, suite] of Object.entries(colorConvert)) {
+		const name = sourceSpace === 'ansi16' ? 'ansi' : sourceSpace;
+		if (sourceSpace === targetSpace) {
+			styles[name] = wrap(identity, offset);
+		} else if (typeof suite === 'object') {
+			styles[name] = wrap(suite[targetSpace], offset);
+		}
+	}
+
+	return styles;
+};
+
+function assembleStyles() {
+	const codes = new Map();
+	const styles = {
+		modifier: {
+			reset: [0, 0],
+			// 21 isn't widely supported and 22 does the same thing
+			bold: [1, 22],
+			dim: [2, 22],
+			italic: [3, 23],
+			underline: [4, 24],
+			inverse: [7, 27],
+			hidden: [8, 28],
+			strikethrough: [9, 29]
+		},
+		color: {
+			black: [30, 39],
+			red: [31, 39],
+			green: [32, 39],
+			yellow: [33, 39],
+			blue: [34, 39],
+			magenta: [35, 39],
+			cyan: [36, 39],
+			white: [37, 39],
+
+			// Bright color
+			blackBright: [90, 39],
+			redBright: [91, 39],
+			greenBright: [92, 39],
+			yellowBright: [93, 39],
+			blueBright: [94, 39],
+			magentaBright: [95, 39],
+			cyanBright: [96, 39],
+			whiteBright: [97, 39]
+		},
+		bgColor: {
+			bgBlack: [40, 49],
+			bgRed: [41, 49],
+			bgGreen: [42, 49],
+			bgYellow: [43, 49],
+			bgBlue: [44, 49],
+			bgMagenta: [45, 49],
+			bgCyan: [46, 49],
+			bgWhite: [47, 49],
+
+			// Bright color
+			bgBlackBright: [100, 49],
+			bgRedBright: [101, 49],
+			bgGreenBright: [102, 49],
+			bgYellowBright: [103, 49],
+			bgBlueBright: [104, 49],
+			bgMagentaBright: [105, 49],
+			bgCyanBright: [106, 49],
+			bgWhiteBright: [107, 49]
+		}
+	};
+
+	// Alias bright black as gray (and grey)
+	styles.color.gray = styles.color.blackBright;
+	styles.bgColor.bgGray = styles.bgColor.bgBlackBright;
+	styles.color.grey = styles.color.blackBright;
+	styles.bgColor.bgGrey = styles.bgColor.bgBlackBright;
+
+	for (const [groupName, group] of Object.entries(styles)) {
+		for (const [styleName, style] of Object.entries(group)) {
+			styles[styleName] = {
+				open: `\u001B[${style[0]}m`,
+				close: `\u001B[${style[1]}m`
+			};
+
+			group[styleName] = styles[styleName];
+
+			codes.set(style[0], style[1]);
+		}
+
+		Object.defineProperty(styles, groupName, {
+			value: group,
+			enumerable: false
+		});
+	}
+
+	Object.defineProperty(styles, 'codes', {
+		value: codes,
+		enumerable: false
+	});
+
+	styles.color.close = '\u001B[39m';
+	styles.bgColor.close = '\u001B[49m';
+
+	setLazyProperty(styles.color, 'ansi', () => makeDynamicStyles(wrapAnsi16, 'ansi16', ansi2ansi, false));
+	setLazyProperty(styles.color, 'ansi256', () => makeDynamicStyles(wrapAnsi256, 'ansi256', ansi2ansi, false));
+	setLazyProperty(styles.color, 'ansi16m', () => makeDynamicStyles(wrapAnsi16m, 'rgb', rgb2rgb, false));
+	setLazyProperty(styles.bgColor, 'ansi', () => makeDynamicStyles(wrapAnsi16, 'ansi16', ansi2ansi, true));
+	setLazyProperty(styles.bgColor, 'ansi256', () => makeDynamicStyles(wrapAnsi256, 'ansi256', ansi2ansi, true));
+	setLazyProperty(styles.bgColor, 'ansi16m', () => makeDynamicStyles(wrapAnsi16m, 'rgb', rgb2rgb, true));
+
+	return styles;
+}
+
+// Make the export immutable
+Object.defineProperty(module, 'exports', {
+	enumerable: true,
+	get: assembleStyles
+});
+
+
+/***/ }),
 /* 664 */,
 /* 665 */,
 /* 666 */,
@@ -57753,389 +59547,161 @@ exports.TraceAPI = TraceAPI;
 
 /***/ }),
 /* 885 */
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(module) {
 
-// Generated by CoffeeScript 1.12.7
-(function() {
-  "use strict";
-  var bom, defaults, events, isEmpty, processItem, processors, sax, setImmediate,
-    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-    extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-    hasProp = {}.hasOwnProperty;
+"use strict";
 
-  sax = __webpack_require__(645);
 
-  events = __webpack_require__(614);
-
-  bom = __webpack_require__(210);
-
-  processors = __webpack_require__(350);
-
-  setImmediate = __webpack_require__(343).setImmediate;
-
-  defaults = __webpack_require__(791).defaults;
-
-  isEmpty = function(thing) {
-    return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
-  };
-
-  processItem = function(processors, item, key) {
-    var i, len, process;
-    for (i = 0, len = processors.length; i < len; i++) {
-      process = processors[i];
-      item = process(item, key);
-    }
-    return item;
-  };
-
-  exports.Parser = (function(superClass) {
-    extend(Parser, superClass);
-
-    function Parser(opts) {
-      this.parseStringPromise = bind(this.parseStringPromise, this);
-      this.parseString = bind(this.parseString, this);
-      this.reset = bind(this.reset, this);
-      this.assignOrPush = bind(this.assignOrPush, this);
-      this.processAsync = bind(this.processAsync, this);
-      var key, ref, value;
-      if (!(this instanceof exports.Parser)) {
-        return new exports.Parser(opts);
-      }
-      this.options = {};
-      ref = defaults["0.2"];
-      for (key in ref) {
-        if (!hasProp.call(ref, key)) continue;
-        value = ref[key];
-        this.options[key] = value;
-      }
-      for (key in opts) {
-        if (!hasProp.call(opts, key)) continue;
-        value = opts[key];
-        this.options[key] = value;
-      }
-      if (this.options.xmlns) {
-        this.options.xmlnskey = this.options.attrkey + "ns";
-      }
-      if (this.options.normalizeTags) {
-        if (!this.options.tagNameProcessors) {
-          this.options.tagNameProcessors = [];
-        }
-        this.options.tagNameProcessors.unshift(processors.normalize);
-      }
-      this.reset();
-    }
-
-    Parser.prototype.processAsync = function() {
-      var chunk, err;
-      try {
-        if (this.remaining.length <= this.options.chunkSize) {
-          chunk = this.remaining;
-          this.remaining = '';
-          this.saxParser = this.saxParser.write(chunk);
-          return this.saxParser.close();
-        } else {
-          chunk = this.remaining.substr(0, this.options.chunkSize);
-          this.remaining = this.remaining.substr(this.options.chunkSize, this.remaining.length);
-          this.saxParser = this.saxParser.write(chunk);
-          return setImmediate(this.processAsync);
-        }
-      } catch (error1) {
-        err = error1;
-        if (!this.saxParser.errThrown) {
-          this.saxParser.errThrown = true;
-          return this.emit(err);
-        }
-      }
-    };
-
-    Parser.prototype.assignOrPush = function(obj, key, newValue) {
-      if (!(key in obj)) {
-        if (!this.options.explicitArray) {
-          return obj[key] = newValue;
-        } else {
-          return obj[key] = [newValue];
-        }
-      } else {
-        if (!(obj[key] instanceof Array)) {
-          obj[key] = [obj[key]];
-        }
-        return obj[key].push(newValue);
-      }
-    };
-
-    Parser.prototype.reset = function() {
-      var attrkey, charkey, ontext, stack;
-      this.removeAllListeners();
-      this.saxParser = sax.parser(this.options.strict, {
-        trim: false,
-        normalize: false,
-        xmlns: this.options.xmlns
-      });
-      this.saxParser.errThrown = false;
-      this.saxParser.onerror = (function(_this) {
-        return function(error) {
-          _this.saxParser.resume();
-          if (!_this.saxParser.errThrown) {
-            _this.saxParser.errThrown = true;
-            return _this.emit("error", error);
-          }
-        };
-      })(this);
-      this.saxParser.onend = (function(_this) {
-        return function() {
-          if (!_this.saxParser.ended) {
-            _this.saxParser.ended = true;
-            return _this.emit("end", _this.resultObject);
-          }
-        };
-      })(this);
-      this.saxParser.ended = false;
-      this.EXPLICIT_CHARKEY = this.options.explicitCharkey;
-      this.resultObject = null;
-      stack = [];
-      attrkey = this.options.attrkey;
-      charkey = this.options.charkey;
-      this.saxParser.onopentag = (function(_this) {
-        return function(node) {
-          var key, newValue, obj, processedKey, ref;
-          obj = {};
-          obj[charkey] = "";
-          if (!_this.options.ignoreAttrs) {
-            ref = node.attributes;
-            for (key in ref) {
-              if (!hasProp.call(ref, key)) continue;
-              if (!(attrkey in obj) && !_this.options.mergeAttrs) {
-                obj[attrkey] = {};
-              }
-              newValue = _this.options.attrValueProcessors ? processItem(_this.options.attrValueProcessors, node.attributes[key], key) : node.attributes[key];
-              processedKey = _this.options.attrNameProcessors ? processItem(_this.options.attrNameProcessors, key) : key;
-              if (_this.options.mergeAttrs) {
-                _this.assignOrPush(obj, processedKey, newValue);
-              } else {
-                obj[attrkey][processedKey] = newValue;
-              }
-            }
-          }
-          obj["#name"] = _this.options.tagNameProcessors ? processItem(_this.options.tagNameProcessors, node.name) : node.name;
-          if (_this.options.xmlns) {
-            obj[_this.options.xmlnskey] = {
-              uri: node.uri,
-              local: node.local
-            };
-          }
-          return stack.push(obj);
-        };
-      })(this);
-      this.saxParser.onclosetag = (function(_this) {
-        return function() {
-          var cdata, emptyStr, key, node, nodeName, obj, objClone, old, s, xpath;
-          obj = stack.pop();
-          nodeName = obj["#name"];
-          if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
-            delete obj["#name"];
-          }
-          if (obj.cdata === true) {
-            cdata = obj.cdata;
-            delete obj.cdata;
-          }
-          s = stack[stack.length - 1];
-          if (obj[charkey].match(/^\s*$/) && !cdata) {
-            emptyStr = obj[charkey];
-            delete obj[charkey];
-          } else {
-            if (_this.options.trim) {
-              obj[charkey] = obj[charkey].trim();
-            }
-            if (_this.options.normalize) {
-              obj[charkey] = obj[charkey].replace(/\s{2,}/g, " ").trim();
-            }
-            obj[charkey] = _this.options.valueProcessors ? processItem(_this.options.valueProcessors, obj[charkey], nodeName) : obj[charkey];
-            if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
-              obj = obj[charkey];
-            }
-          }
-          if (isEmpty(obj)) {
-            obj = _this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr;
-          }
-          if (_this.options.validator != null) {
-            xpath = "/" + ((function() {
-              var i, len, results;
-              results = [];
-              for (i = 0, len = stack.length; i < len; i++) {
-                node = stack[i];
-                results.push(node["#name"]);
-              }
-              return results;
-            })()).concat(nodeName).join("/");
-            (function() {
-              var err;
-              try {
-                return obj = _this.options.validator(xpath, s && s[nodeName], obj);
-              } catch (error1) {
-                err = error1;
-                return _this.emit("error", err);
-              }
-            })();
-          }
-          if (_this.options.explicitChildren && !_this.options.mergeAttrs && typeof obj === 'object') {
-            if (!_this.options.preserveChildrenOrder) {
-              node = {};
-              if (_this.options.attrkey in obj) {
-                node[_this.options.attrkey] = obj[_this.options.attrkey];
-                delete obj[_this.options.attrkey];
-              }
-              if (!_this.options.charsAsChildren && _this.options.charkey in obj) {
-                node[_this.options.charkey] = obj[_this.options.charkey];
-                delete obj[_this.options.charkey];
-              }
-              if (Object.getOwnPropertyNames(obj).length > 0) {
-                node[_this.options.childkey] = obj;
-              }
-              obj = node;
-            } else if (s) {
-              s[_this.options.childkey] = s[_this.options.childkey] || [];
-              objClone = {};
-              for (key in obj) {
-                if (!hasProp.call(obj, key)) continue;
-                objClone[key] = obj[key];
-              }
-              s[_this.options.childkey].push(objClone);
-              delete obj["#name"];
-              if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
-                obj = obj[charkey];
-              }
-            }
-          }
-          if (stack.length > 0) {
-            return _this.assignOrPush(s, nodeName, obj);
-          } else {
-            if (_this.options.explicitRoot) {
-              old = obj;
-              obj = {};
-              obj[nodeName] = old;
-            }
-            _this.resultObject = obj;
-            _this.saxParser.ended = true;
-            return _this.emit("end", _this.resultObject);
-          }
-        };
-      })(this);
-      ontext = (function(_this) {
-        return function(text) {
-          var charChild, s;
-          s = stack[stack.length - 1];
-          if (s) {
-            s[charkey] += text;
-            if (_this.options.explicitChildren && _this.options.preserveChildrenOrder && _this.options.charsAsChildren && (_this.options.includeWhiteChars || text.replace(/\\n/g, '').trim() !== '')) {
-              s[_this.options.childkey] = s[_this.options.childkey] || [];
-              charChild = {
-                '#name': '__text__'
-              };
-              charChild[charkey] = text;
-              if (_this.options.normalize) {
-                charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, " ").trim();
-              }
-              s[_this.options.childkey].push(charChild);
-            }
-            return s;
-          }
-        };
-      })(this);
-      this.saxParser.ontext = ontext;
-      return this.saxParser.oncdata = (function(_this) {
-        return function(text) {
-          var s;
-          s = ontext(text);
-          if (s) {
-            return s.cdata = true;
-          }
-        };
-      })(this);
-    };
-
-    Parser.prototype.parseString = function(str, cb) {
-      var err;
-      if ((cb != null) && typeof cb === "function") {
-        this.on("end", function(result) {
-          this.reset();
-          return cb(null, result);
-        });
-        this.on("error", function(err) {
-          this.reset();
-          return cb(err);
-        });
-      }
-      try {
-        str = str.toString();
-        if (str.trim() === '') {
-          this.emit("end", null);
-          return true;
-        }
-        str = bom.stripBOM(str);
-        if (this.options.async) {
-          this.remaining = str;
-          setImmediate(this.processAsync);
-          return this.saxParser;
-        }
-        return this.saxParser.write(str).close();
-      } catch (error1) {
-        err = error1;
-        if (!(this.saxParser.errThrown || this.saxParser.ended)) {
-          this.emit('error', err);
-          return this.saxParser.errThrown = true;
-        } else if (this.saxParser.ended) {
-          throw err;
-        }
-      }
-    };
-
-    Parser.prototype.parseStringPromise = function(str) {
-      return new Promise((function(_this) {
-        return function(resolve, reject) {
-          return _this.parseString(str, function(err, value) {
-            if (err) {
-              return reject(err);
-            } else {
-              return resolve(value);
-            }
-          });
-        };
-      })(this));
-    };
-
-    return Parser;
-
-  })(events);
-
-  exports.parseString = function(str, a, b) {
-    var cb, options, parser;
-    if (b != null) {
-      if (typeof b === 'function') {
-        cb = b;
-      }
-      if (typeof a === 'object') {
-        options = a;
-      }
-    } else {
-      if (typeof a === 'function') {
-        cb = a;
-      }
-      options = {};
-    }
-    parser = new exports.Parser(options);
-    return parser.parseString(str, cb);
-  };
-
-  exports.parseStringPromise = function(str, a) {
-    var options, parser;
-    if (typeof a === 'object') {
-      options = a;
-    }
-    parser = new exports.Parser(options);
-    return parser.parseStringPromise(str);
-  };
-
-}).call(this);
+module.exports = {
+	"aliceblue": [240, 248, 255],
+	"antiquewhite": [250, 235, 215],
+	"aqua": [0, 255, 255],
+	"aquamarine": [127, 255, 212],
+	"azure": [240, 255, 255],
+	"beige": [245, 245, 220],
+	"bisque": [255, 228, 196],
+	"black": [0, 0, 0],
+	"blanchedalmond": [255, 235, 205],
+	"blue": [0, 0, 255],
+	"blueviolet": [138, 43, 226],
+	"brown": [165, 42, 42],
+	"burlywood": [222, 184, 135],
+	"cadetblue": [95, 158, 160],
+	"chartreuse": [127, 255, 0],
+	"chocolate": [210, 105, 30],
+	"coral": [255, 127, 80],
+	"cornflowerblue": [100, 149, 237],
+	"cornsilk": [255, 248, 220],
+	"crimson": [220, 20, 60],
+	"cyan": [0, 255, 255],
+	"darkblue": [0, 0, 139],
+	"darkcyan": [0, 139, 139],
+	"darkgoldenrod": [184, 134, 11],
+	"darkgray": [169, 169, 169],
+	"darkgreen": [0, 100, 0],
+	"darkgrey": [169, 169, 169],
+	"darkkhaki": [189, 183, 107],
+	"darkmagenta": [139, 0, 139],
+	"darkolivegreen": [85, 107, 47],
+	"darkorange": [255, 140, 0],
+	"darkorchid": [153, 50, 204],
+	"darkred": [139, 0, 0],
+	"darksalmon": [233, 150, 122],
+	"darkseagreen": [143, 188, 143],
+	"darkslateblue": [72, 61, 139],
+	"darkslategray": [47, 79, 79],
+	"darkslategrey": [47, 79, 79],
+	"darkturquoise": [0, 206, 209],
+	"darkviolet": [148, 0, 211],
+	"deeppink": [255, 20, 147],
+	"deepskyblue": [0, 191, 255],
+	"dimgray": [105, 105, 105],
+	"dimgrey": [105, 105, 105],
+	"dodgerblue": [30, 144, 255],
+	"firebrick": [178, 34, 34],
+	"floralwhite": [255, 250, 240],
+	"forestgreen": [34, 139, 34],
+	"fuchsia": [255, 0, 255],
+	"gainsboro": [220, 220, 220],
+	"ghostwhite": [248, 248, 255],
+	"gold": [255, 215, 0],
+	"goldenrod": [218, 165, 32],
+	"gray": [128, 128, 128],
+	"green": [0, 128, 0],
+	"greenyellow": [173, 255, 47],
+	"grey": [128, 128, 128],
+	"honeydew": [240, 255, 240],
+	"hotpink": [255, 105, 180],
+	"indianred": [205, 92, 92],
+	"indigo": [75, 0, 130],
+	"ivory": [255, 255, 240],
+	"khaki": [240, 230, 140],
+	"lavender": [230, 230, 250],
+	"lavenderblush": [255, 240, 245],
+	"lawngreen": [124, 252, 0],
+	"lemonchiffon": [255, 250, 205],
+	"lightblue": [173, 216, 230],
+	"lightcoral": [240, 128, 128],
+	"lightcyan": [224, 255, 255],
+	"lightgoldenrodyellow": [250, 250, 210],
+	"lightgray": [211, 211, 211],
+	"lightgreen": [144, 238, 144],
+	"lightgrey": [211, 211, 211],
+	"lightpink": [255, 182, 193],
+	"lightsalmon": [255, 160, 122],
+	"lightseagreen": [32, 178, 170],
+	"lightskyblue": [135, 206, 250],
+	"lightslategray": [119, 136, 153],
+	"lightslategrey": [119, 136, 153],
+	"lightsteelblue": [176, 196, 222],
+	"lightyellow": [255, 255, 224],
+	"lime": [0, 255, 0],
+	"limegreen": [50, 205, 50],
+	"linen": [250, 240, 230],
+	"magenta": [255, 0, 255],
+	"maroon": [128, 0, 0],
+	"mediumaquamarine": [102, 205, 170],
+	"mediumblue": [0, 0, 205],
+	"mediumorchid": [186, 85, 211],
+	"mediumpurple": [147, 112, 219],
+	"mediumseagreen": [60, 179, 113],
+	"mediumslateblue": [123, 104, 238],
+	"mediumspringgreen": [0, 250, 154],
+	"mediumturquoise": [72, 209, 204],
+	"mediumvioletred": [199, 21, 133],
+	"midnightblue": [25, 25, 112],
+	"mintcream": [245, 255, 250],
+	"mistyrose": [255, 228, 225],
+	"moccasin": [255, 228, 181],
+	"navajowhite": [255, 222, 173],
+	"navy": [0, 0, 128],
+	"oldlace": [253, 245, 230],
+	"olive": [128, 128, 0],
+	"olivedrab": [107, 142, 35],
+	"orange": [255, 165, 0],
+	"orangered": [255, 69, 0],
+	"orchid": [218, 112, 214],
+	"palegoldenrod": [238, 232, 170],
+	"palegreen": [152, 251, 152],
+	"paleturquoise": [175, 238, 238],
+	"palevioletred": [219, 112, 147],
+	"papayawhip": [255, 239, 213],
+	"peachpuff": [255, 218, 185],
+	"peru": [205, 133, 63],
+	"pink": [255, 192, 203],
+	"plum": [221, 160, 221],
+	"powderblue": [176, 224, 230],
+	"purple": [128, 0, 128],
+	"rebeccapurple": [102, 51, 153],
+	"red": [255, 0, 0],
+	"rosybrown": [188, 143, 143],
+	"royalblue": [65, 105, 225],
+	"saddlebrown": [139, 69, 19],
+	"salmon": [250, 128, 114],
+	"sandybrown": [244, 164, 96],
+	"seagreen": [46, 139, 87],
+	"seashell": [255, 245, 238],
+	"sienna": [160, 82, 45],
+	"silver": [192, 192, 192],
+	"skyblue": [135, 206, 235],
+	"slateblue": [106, 90, 205],
+	"slategray": [112, 128, 144],
+	"slategrey": [112, 128, 144],
+	"snow": [255, 250, 250],
+	"springgreen": [0, 255, 127],
+	"steelblue": [70, 130, 180],
+	"tan": [210, 180, 140],
+	"teal": [0, 128, 128],
+	"thistle": [216, 191, 216],
+	"tomato": [255, 99, 71],
+	"turquoise": [64, 224, 208],
+	"violet": [238, 130, 238],
+	"wheat": [245, 222, 179],
+	"white": [255, 255, 255],
+	"whitesmoke": [245, 245, 245],
+	"yellow": [255, 255, 0],
+	"yellowgreen": [154, 205, 50]
+};
 
 
 /***/ }),
@@ -60786,7 +62352,7 @@ exports.exec = exec;
 
   builder = __webpack_require__(476);
 
-  parser = __webpack_require__(885);
+  parser = __webpack_require__(389);
 
   processors = __webpack_require__(350);
 
@@ -66150,4 +67716,26 @@ exports.userAgentPolicy = userAgentPolicy;
 
 
 /***/ })
-/******/ ]);
+/******/ ],
+/******/ function(__webpack_require__) { // webpackRuntimeModules
+/******/ 	"use strict";
+/******/ 
+/******/ 	/* webpack/runtime/node module decorator */
+/******/ 	!function() {
+/******/ 		__webpack_require__.nmd = function(module) {
+/******/ 			module.paths = [];
+/******/ 			if (!module.children) module.children = [];
+/******/ 			Object.defineProperty(module, 'loaded', {
+/******/ 				enumerable: true,
+/******/ 				get: function() { return module.l; }
+/******/ 			});
+/******/ 			Object.defineProperty(module, 'id', {
+/******/ 				enumerable: true,
+/******/ 				get: function() { return module.i; }
+/******/ 			});
+/******/ 			return module;
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ }
+);

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6842,25 +6842,27 @@ function resolveCheckRunId() {
             try {
                 core.info(`Attempting to resolve current GitHub Job (${ctx.runId})`);
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
-                const { data: workflowResponse } = yield octokit.actions
-                    .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: ctx.runId, status: "in_progress" }))
+                let workflowJobs = (yield octokit.actions
+                    .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: ctx.runId }))
                     .catch((e) => {
                     throw `Unable to fetch Workflow Job List: ${e}`;
-                });
-                if (workflowResponse.jobs.length > 0) {
-                    core.info(`resolveCheckRunId() Found ${workflowResponse.jobs.length} Jobs:\n` + util_1.inspect(workflowResponse.jobs));
-                    if (workflowResponse.jobs.length > 1) {
-                        const searchRegExp = new RegExp(`/^` + ctx.job.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + `(\\s+\\(|$)/`);
-                        const jobs = workflowResponse.jobs.filter((run) => searchRegExp.test(run.name));
+                })).data.jobs.filter((job) => job.status === `in_progress`);
+                if (workflowJobs.length > 0) {
+                    core.info(`resolveCheckRunId() Found ${workflowJobs.length} Jobs:\n` + util_1.inspect(workflowJobs));
+                    if (workflowJobs.length > 1) {
+                        const searchRegExp = new RegExp(`^` + ctx.job.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + `(\\s+\\(|$)`);
+                        const jobs = workflowJobs.filter((job) => searchRegExp.test(job.name));
                         core.info(`resolveCheckRunId() Found ${jobs.length} Jobs whose base name is '${ctx.job}'`);
-                        workflowResponse.jobs = jobs.length ? jobs : workflowResponse.jobs;
+                        workflowJobs = jobs.length ? jobs : workflowJobs;
                     }
-                    if (workflowResponse.jobs.length > 1) {
+                    if (workflowJobs.length > 1) {
                         const searchToken = uuid_1.v4();
                         core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
+                        const startedAt = Date.now();
                         // Sleep for MS, to allow Annotation to be captured and populated
-                        yield ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))(5 * 1000);
-                        for (const job of workflowResponse.jobs) {
+                        yield ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))(10 * 1000);
+                        core.info(`Slept for ${Date.now() - startedAt}ms`);
+                        for (const job of workflowJobs) {
                             try {
                                 const { data: annotations } = yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }));
                                 core.info(`resolveCheckRunId() Found ${annotations.length} Annotations for Job '${job.id}':\n` + util_1.inspect(annotations));
@@ -6879,8 +6881,8 @@ function resolveCheckRunId() {
                         }
                         core.info(`resolveCheckRunId() Finished looking for Search Token`);
                     }
-                    else if (workflowResponse.jobs[0]) {
-                        jobId = workflowResponse.jobs[0].id;
+                    else if (workflowJobs[0]) {
+                        jobId = workflowJobs[0].id;
                     }
                     else {
                         throw `Unable to resolve GitHub Job`;

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6843,24 +6843,23 @@ function resolveCheckRunId() {
                 core.info(`Attempting to resolve current GitHub Job (${ctx.runId})`);
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
                 const { data: workflowResponse } = yield octokit.actions
-                    .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: ctx.runId }))
+                    .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: ctx.runId, status: "in_progress" }))
                     .catch((e) => {
                     throw `Unable to fetch Workflow Job List: ${e}`;
                 });
                 if (workflowResponse.jobs.length > 0) {
                     core.info(`resolveCheckRunId() Found ${workflowResponse.jobs.length} Jobs:\n` + util_1.inspect(workflowResponse.jobs));
                     if (workflowResponse.jobs.length > 1) {
-                        const jobs = workflowResponse.jobs.filter((run) => run.name.includes(ctx.job));
-                        core.info(`resolveCheckRunId() Found ${jobs.length} Jobs whose name includes '${ctx.job}'`);
+                        const searchRegExp = new RegExp(`/^` + ctx.job.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + `(\\s+\\(|$)/`);
+                        const jobs = workflowResponse.jobs.filter((run) => searchRegExp.test(run.name));
+                        core.info(`resolveCheckRunId() Found ${jobs.length} Jobs whose base name is '${ctx.job}'`);
                         workflowResponse.jobs = jobs.length ? jobs : workflowResponse.jobs;
                     }
                     if (workflowResponse.jobs.length > 1) {
                         const searchToken = uuid_1.v4();
                         core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
-                        yield ((ms) => {
-                            core.info(`resolveCheckRunId() Sleeping for ${ms / 1000} Seconds`);
-                            return new Promise((resolve) => setTimeout(resolve, ms));
-                        })(2 * 1000);
+                        // Sleep for MS, to allow Annotation to be captured and populated
+                        yield ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))(5 * 1000);
                         for (const job of workflowResponse.jobs) {
                             try {
                                 const { data: annotations } = yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }));

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6825,13 +6825,12 @@ const logLintIssues = (issues) => {
     });
 };
 function resolveCheckRunId() {
-    var _a, _b, _c;
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         let checkRunId = -1;
         if (process.env.GITHUB_ACTIONS === `true`) {
             try {
-                const searchToken = uuid_1.v4();
-                core.info(`::warning::Resolving GitHub CheckRunID (${searchToken})`);
+                core.info(`Attempting to resolve GitHub Check Run`);
                 const ctx = github.context;
                 const ref = (_a = ctx.payload.after) !== null && _a !== void 0 ? _a : ctx.sha;
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
@@ -6846,9 +6845,8 @@ function resolveCheckRunId() {
                         checkRuns = (_b = checkRuns.filter((run) => run.name.includes(ctx.job))) !== null && _b !== void 0 ? _b : checkRuns;
                     }
                     if (checkRuns.length > 1) {
-                        checkRuns = (_c = checkRuns.filter((run) => run.output.annotations_count > 0)) !== null && _c !== void 0 ? _c : checkRuns;
-                    }
-                    if (checkRuns.length > 1) {
+                        const searchToken = uuid_1.v4();
+                        core.info(`::warning::[ignore] Resolving GitHub Check Run with Search Token: ${searchToken}`);
                         for (const run of checkRuns) {
                             try {
                                 if ((yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: run.id }))).data.findIndex((annotation) => annotation.message.includes(searchToken)) !== -1) {
@@ -6863,7 +6861,7 @@ function resolveCheckRunId() {
                     }
                     else if (checkRuns[0]) {
                         checkRunId = checkRuns[0].id;
-                        core.info(`Current Check Run is: ${checkRunId}`);
+                        core.info(`Current Check Run: ${checkRunId}`);
                     }
                     else {
                         throw `Unable to resolve GitHub Check Run`;

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6767,18 +6767,22 @@ function fetchCheckSuiteId(runId) {
                     .catch((e) => {
                     throw `Unable to fetch Workflow Run: ${e}`;
                 });
-                if (currentRun.status === `in_progress`) {
-                    // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
-                    currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;
-                    // The following SHOULD work, but alas
-                    // currentCheckSuiteId = currentRun.check_suite_id
-                    if (currentCheckSuiteId <= 0) {
-                        throw `Error extracting Check Suite ID from: ${currentRun.check_suite_url}`;
-                    }
+                if (!currentRun) {
+                    throw `Unexpected error: No run returned`;
+                }
+                if (currentRun.status !== `in_progress`) {
+                    throw `Unexpected error: Expected status of 'in_progress', got '${currentRun.status}': ` + util_1.inspect(currentRun);
+                }
+                // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
+                currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;
+                // The following SHOULD work, but alas
+                // currentCheckSuiteId = currentRun.check_suite_id
+                if (currentCheckSuiteId <= 0) {
+                    throw `Error extracting Check Suite ID from: ${currentRun.check_suite_url}`;
                 }
             }
             catch (e) {
-                core.info(`::error::Error Fetching Current Run: ${e}`);
+                core.info(`::error::Error Fetching Current Run (${runId}): ${e}`);
             }
         }
         return currentCheckSuiteId;
@@ -6890,7 +6894,6 @@ function resolveCheckRunId(checkRunIdent) {
                 }
                 catch (e) {
                     core.info(`::error::Unable to resolve Check Run ID: ${e}`);
-                    core.info(`checkRunIdent = ` + util_1.inspect(checkRunIdent));
                 }
             }
         }

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6857,6 +6857,10 @@ function resolveCheckRunId() {
                     if (workflowResponse.jobs.length > 1) {
                         const searchToken = uuid_1.v4();
                         core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
+                        yield ((ms) => {
+                            core.info(`resolveCheckRunId() Sleeping for ${ms / 1000} Seconds`);
+                            return new Promise((resolve) => setTimeout(resolve, ms));
+                        })(2 * 1000);
                         for (const job of workflowResponse.jobs) {
                             try {
                                 const { data: annotations } = yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }));

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6840,7 +6840,8 @@ function resolveCheckRunId() {
         const ctx = github.context;
         if (process.env.GITHUB_ACTIONS === `true` && ctx.runId) {
             try {
-                core.info(`Attempting to resolve current GitHub Job (${ctx.runId})`);
+                const searchToken = uuid_1.v4();
+                core.info(`::warning::Attempting to resolve current GitHub Job ${ctx.runId}<${searchToken}>`);
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
                 let workflowJobs = (yield octokit.actions
                     .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: ctx.runId }))
@@ -6856,12 +6857,10 @@ function resolveCheckRunId() {
                         workflowJobs = jobs.length ? jobs : workflowJobs;
                     }
                     if (workflowJobs.length > 1) {
-                        const searchToken = uuid_1.v4();
-                        core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
                         const startedAt = Date.now();
                         // Sleep for MS, to allow Annotation to be captured and populated
                         yield ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))(10 * 1000);
-                        core.info(`Slept for ${Date.now() - startedAt}ms`);
+                        core.info(`Paused for ${Date.now() - startedAt}ms`);
                         for (const job of workflowJobs) {
                             try {
                                 const { data: annotations } = yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }));

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6903,37 +6903,43 @@ function resolveCheckRunId(checkRunIdent) {
 function prepareEnv() {
     return __awaiter(this, void 0, void 0, function* () {
         const startedAt = Date.now();
-        // Resolve Check Run ID
-        const prepareCheckRunIdentPromise = prepareCheckRunIdent();
+        const checkRunPromise = (() => __awaiter(this, void 0, void 0, function* () {
+            let checkRunIdent;
+            try {
+                checkRunIdent = JSON.parse(core.getState(constants_1.Env.CheckRunIdent));
+            }
+            catch (e) {
+                checkRunIdent = undefined;
+            }
+            if (!checkRunIdent) {
+                core.saveState(constants_1.Env.CheckRunIdent, JSON.stringify((checkRunIdent = yield prepareCheckRunIdent())));
+            }
+            return checkRunIdent;
+        }))();
+        const prepareLintPromise = (() => __awaiter(this, void 0, void 0, function* () {
+            let lintPath = core.getState(constants_1.Env.LintPath);
+            if (!lintPath) {
+                core.saveState(constants_1.Env.LintPath, (lintPath = yield prepareLint()));
+            }
+            return lintPath;
+        }))();
+        const patchPromise = (() => __awaiter(this, void 0, void 0, function* () {
+            let patchPath = core.getState(constants_1.Env.PatchPath);
+            if (!patchPath) {
+                core.saveState(constants_1.Env.PatchPath, (patchPath = yield fetchPatch()));
+            }
+            return patchPath;
+        }))();
         // Prepare cache, lint and go in parallel.
         const restoreCachePromise = cache_1.restoreCache();
-        const prepareLintPromise = prepareLint();
         const installGoPromise = install_1.installGo();
-        const patchPromise = fetchPatch();
-        core.saveState(constants_1.Env.LintPath, yield prepareLintPromise);
+        const lintPath = yield prepareLintPromise;
+        const patchPath = yield patchPromise;
+        const checkRunIdent = yield checkRunPromise;
         yield installGoPromise;
         yield restoreCachePromise;
-        core.saveState(constants_1.Env.PatchPath, yield patchPromise);
-        core.saveState(constants_1.Env.CheckRunIdent, JSON.stringify(yield prepareCheckRunIdentPromise));
         core.info(`Prepared env in ${Date.now() - startedAt}ms`);
-    });
-}
-function restoreEnv() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const startedAt = Date.now();
-        const lintPath = core.getState(constants_1.Env.LintPath);
-        const patchPath = core.getState(constants_1.Env.PatchPath);
-        let checkRunId;
-        try {
-            const checkRunIdent = JSON.parse(core.getState(constants_1.Env.CheckRunIdent));
-            checkRunId = yield resolveCheckRunId(checkRunIdent);
-        }
-        catch (e) {
-            core.info(`::error::Error Resolving Check Run ID: ${e}`);
-            checkRunId = -1;
-        }
-        core.info(`Restored env in ${Date.now() - startedAt}ms`);
-        return { lintPath, patchPath, checkRunId };
+        return { lintPath, patchPath, checkRunIdent };
     });
 }
 var LintSeverity;
@@ -7200,10 +7206,10 @@ function runLint(lintPath, patchPath, checkRunId) {
 function setup() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield core.group(`prepare environment`, prepareEnv);
+            yield core.group(`pre-prepare environment`, prepareEnv);
         }
         catch (error) {
-            core.error(`Failed to prepare: ${error}, ${error.stack}`);
+            core.error(`Failed to pre-prepare: ${error}, ${error.stack}`);
             core.setFailed(error.message);
         }
     });
@@ -7212,8 +7218,16 @@ exports.setup = setup;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const { lintPath, patchPath, checkRunId } = yield core.group(`restore environment`, restoreEnv);
+            const { lintPath, patchPath, checkRunIdent } = yield core.group(`prepare environment`, prepareEnv);
             core.addPath(path.dirname(lintPath));
+            let checkRunId;
+            try {
+                checkRunId = yield resolveCheckRunId(checkRunIdent);
+            }
+            catch (e) {
+                core.info(`::error::Error Resolving Check Run ID: ${e}`);
+                checkRunId = -1;
+            }
             yield core.group(`run golangci-lint`, () => runLint(lintPath, patchPath, checkRunId));
         }
         catch (error) {

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6770,8 +6770,8 @@ function fetchCheckSuiteId(runId) {
                 if (!currentRun) {
                     throw `Unexpected error: No run returned`;
                 }
-                if (currentRun.status !== `in_progress`) {
-                    throw `Unexpected error: Expected status of 'in_progress', got '${currentRun.status}': ` + util_1.inspect(currentRun);
+                if (currentRun.conclusion) {
+                    throw `Unexpected error: Expected Check Suite with no conclusion, got: ` + util_1.inspect(currentRun);
                 }
                 // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
                 currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6835,37 +6835,46 @@ const logLintIssues = (issues) => {
     });
 };
 function resolveCheckRunId() {
-    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         let jobId = -1;
-        if (process.env.GITHUB_ACTIONS === `true` && process.env.GITHUB_RUN_ID) {
+        const ctx = github.context;
+        if (process.env.GITHUB_ACTIONS === `true` && ctx.runId) {
             try {
-                core.info(`Attempting to resolve current GitHub Job`);
-                const ctx = github.context;
+                core.info(`Attempting to resolve current GitHub Job (${ctx.runId})`);
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
                 const { data: workflowResponse } = yield octokit.actions
-                    .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: parseInt(process.env.GITHUB_RUN_ID) }))
+                    .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: ctx.runId }))
                     .catch((e) => {
                     throw `Unable to fetch Workflow Job List: ${e}`;
                 });
                 if (workflowResponse.jobs.length > 0) {
+                    core.info(`resolveCheckRunId() Found ${workflowResponse.jobs.length} Jobs:\n` + util_1.inspect(workflowResponse.jobs));
                     if (workflowResponse.jobs.length > 1) {
-                        workflowResponse.jobs = (_a = workflowResponse.jobs.filter((run) => run.name.includes(ctx.job))) !== null && _a !== void 0 ? _a : workflowResponse.jobs;
+                        const jobs = workflowResponse.jobs.filter((run) => run.name.includes(ctx.job));
+                        core.info(`resolveCheckRunId() Found ${jobs.length} Jobs whose name includes '${ctx.job}'`);
+                        workflowResponse.jobs = jobs.length ? jobs : workflowResponse.jobs;
                     }
                     if (workflowResponse.jobs.length > 1) {
                         const searchToken = uuid_1.v4();
                         core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
                         for (const job of workflowResponse.jobs) {
                             try {
-                                if ((yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }))).data.findIndex((annotation) => annotation.message.includes(searchToken)) !== -1) {
+                                const { data: annotations } = yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }));
+                                core.info(`resolveCheckRunId() Found ${annotations.length} Annotations for Job '${job.id}':\n` + util_1.inspect(annotations));
+                                if (annotations.findIndex((annotation) => {
+                                    core.info(`resolveCheckRunId() Looking for Search Token (${searchToken}) in message: ${annotation.message}`);
+                                    return annotation.message.includes(searchToken);
+                                }) !== -1) {
+                                    core.info(`resolveCheckRunId() Found Search Token (${searchToken}) in Job ${job.id}`);
                                     jobId = job.id;
                                     break;
                                 }
                             }
                             catch (e) {
-                                core.info(`::debug::Error Fetching Job ${job.id}: ${e}`);
+                                core.info(`resolveCheckRunId() Error Fetching Job ${job.id}: ${e}`);
                             }
                         }
+                        core.info(`resolveCheckRunId() Finished looking for Search Token`);
                     }
                     else if (workflowResponse.jobs[0]) {
                         jobId = workflowResponse.jobs[0].id;
@@ -6884,7 +6893,7 @@ function resolveCheckRunId() {
             }
         }
         else {
-            core.info(`::debug::Not in GitHub Action Context, Skipping Job Resolution`);
+            core.info(`Not in GitHub Action Context, Skipping Job Resolution`);
         }
         return jobId;
     });

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -6798,8 +6798,9 @@ const parseOutput = (json) => {
     }
     if (lintOutput.Issues.length) {
         lintOutput.Issues = lintOutput.Issues.filter((issue) => issue.Severity !== `ignore`).map((issue) => {
-            const Severity = issue.Severity.toLowerCase();
-            issue.Severity = severityMap[`${Severity}`] ? severityMap[`${Severity}`] : `failure`;
+            issue.Severity = ((Severity) => {
+                return severityMap[`${Severity}`] ? severityMap[`${Severity}`] : `failure`;
+            })(issue.Severity.toLowerCase());
             return issue;
         });
     }
@@ -6807,21 +6808,30 @@ const parseOutput = (json) => {
 };
 const logLintIssues = (issues) => {
     issues.forEach((issue) => {
-        let header = `${ansi_styles_1.default.red.open}${ansi_styles_1.default.bold.open}Lint Error:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.red.close}`;
-        if (issue.Severity === `warning`) {
-            header = `${ansi_styles_1.default.yellow.open}${ansi_styles_1.default.bold.open}Lint Warning:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.yellow.close}`;
-        }
-        else if (issue.Severity === `notice`) {
-            header = `${ansi_styles_1.default.cyan.open}${ansi_styles_1.default.bold.open}Lint Notice:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.cyan.close}`;
-        }
-        let pos = `${issue.Pos.Filename}:${issue.Pos.Line}`;
-        if (issue.LineRange !== undefined) {
-            pos += `-${issue.LineRange.To}`;
-        }
-        else if (issue.Pos.Column) {
-            pos += `:${issue.Pos.Column}`;
-        }
-        core.info(`${header} ${pos} - ${issue.Text} (${issue.FromLinter})`);
+        core.info(((issue) => {
+            switch (issue.Severity) {
+                case `warning`:
+                    return `${ansi_styles_1.default.yellow.open}${ansi_styles_1.default.bold.open}Lint Warning:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.yellow.close}`;
+                case `notice`:
+                    return `${ansi_styles_1.default.cyan.open}${ansi_styles_1.default.bold.open}Lint Notice:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.cyan.close}`;
+                default:
+                    return `${ansi_styles_1.default.red.open}${ansi_styles_1.default.bold.open}Lint Error:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.red.close}`;
+            }
+        })(issue) +
+            ` ` +
+            `${issue.Pos.Filename}:${issue.Pos.Line}` +
+            ((issue) => {
+                if (issue.LineRange !== undefined) {
+                    return `-${issue.LineRange.To}`;
+                }
+                else if (issue.Pos.Column) {
+                    return `:${issue.Pos.Column}`;
+                }
+                else {
+                    return ``;
+                }
+            })(issue) +
+            ` - ${issue.Text} (${issue.FromLinter})`);
     });
 };
 function resolveCheckRunId() {
@@ -6894,77 +6904,52 @@ function annotateLintIssues(issues, checkRunId) {
         };
         const ctx = github.context;
         const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
-        const githubAnnotations = issues.map((issue) => {
-            // If/when we transition to comments, we would build the request structure here
-            const annotation = {
-                path: issue.Pos.Filename,
-                start_line: issue.Pos.Line,
-                end_line: issue.Pos.Line,
-                title: issue.FromLinter,
-                message: issue.Text,
-                annotation_level: issue.Severity,
-            };
-            issueCounts[issue.Severity]++;
-            if (issue.LineRange !== undefined) {
-                annotation.end_line = issue.LineRange.To;
-            }
-            else if (issue.Pos.Column) {
-                annotation.start_column = issue.Pos.Column;
-                annotation.end_column = issue.Pos.Column;
-            }
-            if (issue.Replacement !== null) {
-                let replacement = ``;
-                if (issue.Replacement.Inline) {
-                    replacement =
-                        issue.SourceLines[0].slice(0, issue.Replacement.Inline.StartCol) +
-                            issue.Replacement.Inline.NewString +
-                            issue.SourceLines[0].slice(issue.Replacement.Inline.StartCol + issue.Replacement.Inline.Length);
-                }
-                else if (issue.Replacement.NewLines) {
-                    replacement = issue.Replacement.NewLines.join("\n");
-                }
-                annotation.raw_details = "```suggestion\n" + replacement + "\n```";
-            }
-            return annotation;
-        });
         const title = `GolangCI-Lint`;
-        const summary = `There are {issueCounts.failure} failures, {issueCounts.wairning} warnings, and {issueCounts.notice} notices.`;
-        Array.from({ length: Math.ceil(githubAnnotations.length / chunkSize) }, (v, i) => githubAnnotations.slice(i * chunkSize, i * chunkSize + chunkSize)).forEach((annotations) => {
+        for (let i = 0; i < Math.ceil(issues.length / chunkSize); i++) {
             octokit.checks
                 .update(Object.assign(Object.assign({}, ctx.repo), { check_run_id: checkRunId, output: {
-                    title,
-                    summary,
-                    annotations,
+                    title: title,
+                    annotations: issues.slice(i * chunkSize, i * chunkSize + chunkSize).map((issue) => {
+                        // If/when we transition to comments, we would build the request structure here
+                        const annotation = {
+                            path: issue.Pos.Filename,
+                            start_line: issue.Pos.Line,
+                            end_line: issue.Pos.Line,
+                            title: issue.FromLinter,
+                            message: issue.Text,
+                            annotation_level: issue.Severity,
+                        };
+                        issueCounts[issue.Severity]++;
+                        if (issue.LineRange !== undefined) {
+                            annotation.end_line = issue.LineRange.To;
+                        }
+                        else if (issue.Pos.Column) {
+                            annotation.start_column = issue.Pos.Column;
+                            annotation.end_column = issue.Pos.Column;
+                        }
+                        if (issue.Replacement !== null) {
+                            let replacement = ``;
+                            if (issue.Replacement.Inline) {
+                                replacement =
+                                    issue.SourceLines[0].slice(0, issue.Replacement.Inline.StartCol) +
+                                        issue.Replacement.Inline.NewString +
+                                        issue.SourceLines[0].slice(issue.Replacement.Inline.StartCol + issue.Replacement.Inline.Length);
+                            }
+                            else if (issue.Replacement.NewLines) {
+                                replacement = issue.Replacement.NewLines.join("\n");
+                            }
+                            annotation.raw_details = "```suggestion\n" + replacement + "\n```";
+                        }
+                        return annotation;
+                    }),
+                    summary: `There are {issueCounts.failure} failures, {issueCounts.wairning} warnings, and {issueCounts.notice} notices.`,
                 } }))
                 .catch((e) => {
                 throw `Error patching Check Run Data (annotations): ${e}`;
             });
-        });
+        }
     });
 }
-const hasFailingIssues = (issues) => {
-    // If the user input is not a valid Severity Level, this will be -1, and any issue will fail
-    const userFailureSeverity = core.getInput(`failure-severity`).toLowerCase();
-    let failureSeverity = DefaultFailureSeverity;
-    if (userFailureSeverity) {
-        failureSeverity = Object.values(LintSeverity).indexOf(userFailureSeverity);
-    }
-    if (failureSeverity < 0) {
-        core.info(`::warning::failure-severity must be one of (${Object.keys(LintSeverity).join(" | ")}). "${userFailureSeverity}" not supported, using default (${LintSeverity[DefaultFailureSeverity]})`);
-        failureSeverity = DefaultFailureSeverity;
-    }
-    if (issues.length) {
-        if (failureSeverity <= 0) {
-            return true;
-        }
-        for (const issue of issues) {
-            if (failureSeverity <= LintSeverity[issue.Severity]) {
-                return true;
-            }
-        }
-    }
-    return false;
-};
 const printOutput = (res) => {
     if (res.stdout) {
         core.info(res.stdout);
@@ -6973,56 +6958,39 @@ const printOutput = (res) => {
         core.info(res.stderr);
     }
 };
-function printLintOutput(res, checkRunId) {
-    var _a;
+function processLintOutput(res, checkRunId) {
     return __awaiter(this, void 0, void 0, function* () {
-        let lintOutput;
-        const exit_code = (_a = res.code) !== null && _a !== void 0 ? _a : 0;
-        try {
-            if (res.stdout) {
-                try {
-                    // This object contains other information, such as errors and the active linters
-                    // TODO: Should we do something with that data?
-                    lintOutput = parseOutput(res.stdout);
-                    if (lintOutput.Issues.length) {
-                        logLintIssues(lintOutput.Issues);
-                        // We can only Annotate (or Comment) on Push or Pull Request
-                        switch (github.context.eventName) {
-                            case `pull_request`:
-                            // TODO: When we are ready to handle these as Comments, instead of Annotations, we would place that logic here
-                            /* falls through */
-                            case `push`:
-                                yield annotateLintIssues(lintOutput.Issues, checkRunId);
-                                break;
-                            default:
-                                // At this time, other events are not supported
-                                break;
-                        }
+        let lintIssues = [];
+        if (res.stdout) {
+            try {
+                // This object contains other information, such as errors and the active linters
+                // TODO: Should we do something with that data?
+                ;
+                ({ Issues: lintIssues } = parseOutput(res.stdout));
+                if (lintIssues.length) {
+                    logLintIssues(lintIssues);
+                    // We can only Annotate (or Comment) on Push or Pull Request
+                    switch (github.context.eventName) {
+                        case `pull_request`:
+                        // TODO: When we are ready to handle these as Comments, instead of Annotations, we would place that logic here
+                        /* falls through */
+                        case `push`:
+                            yield annotateLintIssues(lintIssues, checkRunId);
+                            break;
+                        default:
+                            // At this time, other events are not supported
+                            break;
                     }
                 }
-                catch (e) {
-                    throw `there was an error processing golangci-lint output: ${e}`;
-                }
             }
-            if (res.stderr) {
-                core.info(res.stderr);
-            }
-            if (exit_code === 1) {
-                if (!lintOutput) {
-                    throw `unexpected state, golangci-lint exited with 1, but provided no lint output`;
-                }
-                if (hasFailingIssues(lintOutput.Issues)) {
-                    throw `issues found`;
-                }
-            }
-            else if (exit_code > 1) {
-                throw `golangci-lint exit with code ${exit_code}`;
+            catch (e) {
+                core.setFailed(`Error processing golangci-lint output: ${e}`);
             }
         }
-        catch (e) {
-            return core.setFailed(`${e}`);
+        if (res.stderr) {
+            core.info(res.stderr);
         }
-        return core.info(`golangci-lint found no blocking issues`);
+        return lintIssues;
     });
 }
 function runLint(lintPath, patchPath, checkRunId) {
@@ -7032,6 +7000,17 @@ function runLint(lintPath, patchPath, checkRunId) {
             const res = yield execShellCommand(`${lintPath} cache status`);
             printOutput(res);
         }
+        const failureSeverity = ((userFailureSeverity) => {
+            if (userFailureSeverity) {
+                if (Object.values(LintSeverity).indexOf(userFailureSeverity) != -1) {
+                    return Object.values(LintSeverity).indexOf(userFailureSeverity);
+                }
+                else {
+                    core.info(`::warning::failure-severity must be one of (${Object.keys(LintSeverity).join(" | ")}). "${userFailureSeverity}" not supported, using default (${LintSeverity[DefaultFailureSeverity]})`);
+                }
+            }
+            return DefaultFailureSeverity;
+        })(core.getInput(`failure-severity`).toLowerCase());
         const userArgs = core.getInput(`args`);
         const addedArgs = [];
         const userArgNames = new Set();
@@ -7073,14 +7052,29 @@ function runLint(lintPath, patchPath, checkRunId) {
         const cmd = `${lintPath} run ${addedArgs.join(` `)} ${userArgs}`.trimRight();
         core.info(`Running [${cmd}] in [${cmdArgs.cwd || ``}] ...`);
         const startedAt = Date.now();
+        let exit_code = 0;
         try {
             const res = yield execShellCommand(cmd, cmdArgs);
-            yield printLintOutput(res, checkRunId);
+            processLintOutput(res, checkRunId);
         }
         catch (exc) {
             // This logging passes issues to GitHub annotations but comments can be more convenient for some users.
             // TODO: support reviewdog or leaving comments by GitHub API.
-            yield printLintOutput(exc, checkRunId);
+            const issuesPromise = processLintOutput(exc, checkRunId);
+            if (exc.code !== 1 || (yield issuesPromise).findIndex((issue) => LintSeverity[issue.Severity] >= failureSeverity) != -1) {
+                exit_code = exc.code;
+            }
+        }
+        finally {
+            if (exit_code === 0) {
+                core.info(`golangci-lint found no blocking issues`);
+            }
+            else if (exit_code === 1) {
+                core.setFailed(`issues found`);
+            }
+            else {
+                core.setFailed(`golangci-lint exit with code ${exit_code}`);
+            }
         }
         core.info(`Ran golangci-lint in ${Date.now() - startedAt}ms`);
     });

--- a/dist/pre/index.js
+++ b/dist/pre/index.js
@@ -40,7 +40,7 @@ module.exports =
 /******/ 	// the startup function
 /******/ 	function startup() {
 /******/ 		// Load entry module and return exports
-/******/ 		return __webpack_require__(131);
+/******/ 		return __webpack_require__(526);
 /******/ 	};
 /******/ 	// initialize runtime
 /******/ 	runtime(__webpack_require__);
@@ -4662,17 +4662,7 @@ module.exports = require("child_process");
 
 /***/ }),
 /* 130 */,
-/* 131 */
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
-
-"use strict";
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const run_1 = __webpack_require__(180);
-run_1.run();
-
-
-/***/ }),
+/* 131 */,
 /* 132 */,
 /* 133 */,
 /* 134 */,
@@ -44181,7 +44171,17 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 /* 525 */,
-/* 526 */,
+/* 526 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+const run_1 = __webpack_require__(180);
+run_1.setup();
+
+
+/***/ }),
 /* 527 */,
 /* 528 */,
 /* 529 */,

--- a/dist/pre/index.js
+++ b/dist/pre/index.js
@@ -6767,18 +6767,22 @@ function fetchCheckSuiteId(runId) {
                     .catch((e) => {
                     throw `Unable to fetch Workflow Run: ${e}`;
                 });
-                if (currentRun.status === `in_progress`) {
-                    // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
-                    currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;
-                    // The following SHOULD work, but alas
-                    // currentCheckSuiteId = currentRun.check_suite_id
-                    if (currentCheckSuiteId <= 0) {
-                        throw `Error extracting Check Suite ID from: ${currentRun.check_suite_url}`;
-                    }
+                if (!currentRun) {
+                    throw `Unexpected error: No run returned`;
+                }
+                if (currentRun.status !== `in_progress`) {
+                    throw `Unexpected error: Expected status of 'in_progress', got '${currentRun.status}': ` + util_1.inspect(currentRun);
+                }
+                // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
+                currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;
+                // The following SHOULD work, but alas
+                // currentCheckSuiteId = currentRun.check_suite_id
+                if (currentCheckSuiteId <= 0) {
+                    throw `Error extracting Check Suite ID from: ${currentRun.check_suite_url}`;
                 }
             }
             catch (e) {
-                core.info(`::error::Error Fetching Current Run: ${e}`);
+                core.info(`::error::Error Fetching Current Run (${runId}): ${e}`);
             }
         }
         return currentCheckSuiteId;
@@ -6890,7 +6894,6 @@ function resolveCheckRunId(checkRunIdent) {
                 }
                 catch (e) {
                     core.info(`::error::Unable to resolve Check Run ID: ${e}`);
-                    core.info(`checkRunIdent = ` + util_1.inspect(checkRunIdent));
                 }
             }
         }

--- a/dist/pre/index.js
+++ b/dist/pre/index.js
@@ -6903,37 +6903,43 @@ function resolveCheckRunId(checkRunIdent) {
 function prepareEnv() {
     return __awaiter(this, void 0, void 0, function* () {
         const startedAt = Date.now();
-        // Resolve Check Run ID
-        const prepareCheckRunIdentPromise = prepareCheckRunIdent();
+        const checkRunPromise = (() => __awaiter(this, void 0, void 0, function* () {
+            let checkRunIdent;
+            try {
+                checkRunIdent = JSON.parse(core.getState(constants_1.Env.CheckRunIdent));
+            }
+            catch (e) {
+                checkRunIdent = undefined;
+            }
+            if (!checkRunIdent) {
+                core.saveState(constants_1.Env.CheckRunIdent, JSON.stringify((checkRunIdent = yield prepareCheckRunIdent())));
+            }
+            return checkRunIdent;
+        }))();
+        const prepareLintPromise = (() => __awaiter(this, void 0, void 0, function* () {
+            let lintPath = core.getState(constants_1.Env.LintPath);
+            if (!lintPath) {
+                core.saveState(constants_1.Env.LintPath, (lintPath = yield prepareLint()));
+            }
+            return lintPath;
+        }))();
+        const patchPromise = (() => __awaiter(this, void 0, void 0, function* () {
+            let patchPath = core.getState(constants_1.Env.PatchPath);
+            if (!patchPath) {
+                core.saveState(constants_1.Env.PatchPath, (patchPath = yield fetchPatch()));
+            }
+            return patchPath;
+        }))();
         // Prepare cache, lint and go in parallel.
         const restoreCachePromise = cache_1.restoreCache();
-        const prepareLintPromise = prepareLint();
         const installGoPromise = install_1.installGo();
-        const patchPromise = fetchPatch();
-        core.saveState(constants_1.Env.LintPath, yield prepareLintPromise);
+        const lintPath = yield prepareLintPromise;
+        const patchPath = yield patchPromise;
+        const checkRunIdent = yield checkRunPromise;
         yield installGoPromise;
         yield restoreCachePromise;
-        core.saveState(constants_1.Env.PatchPath, yield patchPromise);
-        core.saveState(constants_1.Env.CheckRunIdent, JSON.stringify(yield prepareCheckRunIdentPromise));
         core.info(`Prepared env in ${Date.now() - startedAt}ms`);
-    });
-}
-function restoreEnv() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const startedAt = Date.now();
-        const lintPath = core.getState(constants_1.Env.LintPath);
-        const patchPath = core.getState(constants_1.Env.PatchPath);
-        let checkRunId;
-        try {
-            const checkRunIdent = JSON.parse(core.getState(constants_1.Env.CheckRunIdent));
-            checkRunId = yield resolveCheckRunId(checkRunIdent);
-        }
-        catch (e) {
-            core.info(`::error::Error Resolving Check Run ID: ${e}`);
-            checkRunId = -1;
-        }
-        core.info(`Restored env in ${Date.now() - startedAt}ms`);
-        return { lintPath, patchPath, checkRunId };
+        return { lintPath, patchPath, checkRunIdent };
     });
 }
 var LintSeverity;
@@ -7200,10 +7206,10 @@ function runLint(lintPath, patchPath, checkRunId) {
 function setup() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield core.group(`prepare environment`, prepareEnv);
+            yield core.group(`pre-prepare environment`, prepareEnv);
         }
         catch (error) {
-            core.error(`Failed to prepare: ${error}, ${error.stack}`);
+            core.error(`Failed to pre-prepare: ${error}, ${error.stack}`);
             core.setFailed(error.message);
         }
     });
@@ -7212,8 +7218,16 @@ exports.setup = setup;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const { lintPath, patchPath, checkRunId } = yield core.group(`restore environment`, restoreEnv);
+            const { lintPath, patchPath, checkRunIdent } = yield core.group(`prepare environment`, prepareEnv);
             core.addPath(path.dirname(lintPath));
+            let checkRunId;
+            try {
+                checkRunId = yield resolveCheckRunId(checkRunIdent);
+            }
+            catch (e) {
+                core.info(`::error::Error Resolving Check Run ID: ${e}`);
+                checkRunId = -1;
+            }
             yield core.group(`run golangci-lint`, () => runLint(lintPath, patchPath, checkRunId));
         }
         catch (error) {

--- a/dist/pre/index.js
+++ b/dist/pre/index.js
@@ -6770,8 +6770,8 @@ function fetchCheckSuiteId(runId) {
                 if (!currentRun) {
                     throw `Unexpected error: No run returned`;
                 }
-                if (currentRun.status !== `in_progress`) {
-                    throw `Unexpected error: Expected status of 'in_progress', got '${currentRun.status}': ` + util_1.inspect(currentRun);
+                if (currentRun.conclusion) {
+                    throw `Unexpected error: Expected Check Suite with no conclusion, got: ` + util_1.inspect(currentRun);
                 }
                 // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
                 currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6835,13 +6835,12 @@ const logLintIssues = (issues) => {
     });
 };
 function resolveCheckRunId() {
-    var _a, _b, _c;
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         let checkRunId = -1;
         if (process.env.GITHUB_ACTIONS === `true`) {
             try {
-                const searchToken = uuid_1.v4();
-                core.info(`::warning::Resolving GitHub CheckRunID (${searchToken})`);
+                core.info(`Attempting to resolve GitHub Check Run`);
                 const ctx = github.context;
                 const ref = (_a = ctx.payload.after) !== null && _a !== void 0 ? _a : ctx.sha;
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
@@ -6856,9 +6855,8 @@ function resolveCheckRunId() {
                         checkRuns = (_b = checkRuns.filter((run) => run.name.includes(ctx.job))) !== null && _b !== void 0 ? _b : checkRuns;
                     }
                     if (checkRuns.length > 1) {
-                        checkRuns = (_c = checkRuns.filter((run) => run.output.annotations_count > 0)) !== null && _c !== void 0 ? _c : checkRuns;
-                    }
-                    if (checkRuns.length > 1) {
+                        const searchToken = uuid_1.v4();
+                        core.info(`::warning::[ignore] Resolving GitHub Check Run with Search Token: ${searchToken}`);
                         for (const run of checkRuns) {
                             try {
                                 if ((yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: run.id }))).data.findIndex((annotation) => annotation.message.includes(searchToken)) !== -1) {
@@ -6873,7 +6871,7 @@ function resolveCheckRunId() {
                     }
                     else if (checkRuns[0]) {
                         checkRunId = checkRuns[0].id;
-                        core.info(`Current Check Run is: ${checkRunId}`);
+                        core.info(`Current Check Run: ${checkRunId}`);
                     }
                     else {
                         throw `Unable to resolve GitHub Check Run`;

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6777,18 +6777,22 @@ function fetchCheckSuiteId(runId) {
                     .catch((e) => {
                     throw `Unable to fetch Workflow Run: ${e}`;
                 });
-                if (currentRun.status === `in_progress`) {
-                    // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
-                    currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;
-                    // The following SHOULD work, but alas
-                    // currentCheckSuiteId = currentRun.check_suite_id
-                    if (currentCheckSuiteId <= 0) {
-                        throw `Error extracting Check Suite ID from: ${currentRun.check_suite_url}`;
-                    }
+                if (!currentRun) {
+                    throw `Unexpected error: No run returned`;
+                }
+                if (currentRun.status !== `in_progress`) {
+                    throw `Unexpected error: Expected status of 'in_progress', got '${currentRun.status}': ` + util_1.inspect(currentRun);
+                }
+                // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
+                currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;
+                // The following SHOULD work, but alas
+                // currentCheckSuiteId = currentRun.check_suite_id
+                if (currentCheckSuiteId <= 0) {
+                    throw `Error extracting Check Suite ID from: ${currentRun.check_suite_url}`;
                 }
             }
             catch (e) {
-                core.info(`::error::Error Fetching Current Run: ${e}`);
+                core.info(`::error::Error Fetching Current Run (${runId}): ${e}`);
             }
         }
         return currentCheckSuiteId;
@@ -6900,7 +6904,6 @@ function resolveCheckRunId(checkRunIdent) {
                 }
                 catch (e) {
                     core.info(`::error::Unable to resolve Check Run ID: ${e}`);
-                    core.info(`checkRunIdent = ` + util_1.inspect(checkRunIdent));
                 }
             }
         }

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6850,7 +6850,8 @@ function resolveCheckRunId() {
         const ctx = github.context;
         if (process.env.GITHUB_ACTIONS === `true` && ctx.runId) {
             try {
-                core.info(`Attempting to resolve current GitHub Job (${ctx.runId})`);
+                const searchToken = uuid_1.v4();
+                core.info(`::warning::Attempting to resolve current GitHub Job ${ctx.runId}<${searchToken}>`);
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
                 let workflowJobs = (yield octokit.actions
                     .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: ctx.runId }))
@@ -6866,12 +6867,10 @@ function resolveCheckRunId() {
                         workflowJobs = jobs.length ? jobs : workflowJobs;
                     }
                     if (workflowJobs.length > 1) {
-                        const searchToken = uuid_1.v4();
-                        core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
                         const startedAt = Date.now();
                         // Sleep for MS, to allow Annotation to be captured and populated
                         yield ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))(10 * 1000);
-                        core.info(`Slept for ${Date.now() - startedAt}ms`);
+                        core.info(`Paused for ${Date.now() - startedAt}ms`);
                         for (const job of workflowJobs) {
                             try {
                                 const { data: annotations } = yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }));

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6845,60 +6845,58 @@ const logLintIssues = (issues) => {
     });
 };
 function resolveCheckRunId() {
-    var _a, _b;
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
-        let checkRunId = -1;
-        if (process.env.GITHUB_ACTIONS === `true`) {
+        let jobId = -1;
+        if (process.env.GITHUB_ACTIONS === `true` && process.env.GITHUB_RUN_ID) {
             try {
-                core.info(`Attempting to resolve GitHub Check Run`);
+                core.info(`Attempting to resolve current GitHub Job`);
                 const ctx = github.context;
-                const ref = (_a = ctx.payload.after) !== null && _a !== void 0 ? _a : ctx.sha;
                 const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
-                const { data: checkRunsResponse } = yield octokit.checks
-                    .listForRef(Object.assign(Object.assign({}, ctx.repo), { ref, status: `in_progress`, filter: `latest` }))
+                const { data: workflowResponse } = yield octokit.actions
+                    .listJobsForWorkflowRun(Object.assign(Object.assign({}, ctx.repo), { run_id: parseInt(process.env.GITHUB_RUN_ID) }))
                     .catch((e) => {
-                    throw `Unable to fetch Check Run List: ${e}`;
+                    throw `Unable to fetch Workflow Job List: ${e}`;
                 });
-                if (checkRunsResponse.check_runs.length > 0) {
-                    let checkRuns = checkRunsResponse.check_runs;
-                    if (checkRuns.length > 1) {
-                        checkRuns = (_b = checkRuns.filter((run) => run.name.includes(ctx.job))) !== null && _b !== void 0 ? _b : checkRuns;
+                if (workflowResponse.jobs.length > 0) {
+                    if (workflowResponse.jobs.length > 1) {
+                        workflowResponse.jobs = (_a = workflowResponse.jobs.filter((run) => run.name.includes(ctx.job))) !== null && _a !== void 0 ? _a : workflowResponse.jobs;
                     }
-                    if (checkRuns.length > 1) {
+                    if (workflowResponse.jobs.length > 1) {
                         const searchToken = uuid_1.v4();
-                        core.info(`::warning::[ignore] Resolving GitHub Check Run with Search Token: ${searchToken}`);
-                        for (const run of checkRuns) {
+                        core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
+                        for (const job of workflowResponse.jobs) {
                             try {
-                                if ((yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: run.id }))).data.findIndex((annotation) => annotation.message.includes(searchToken)) !== -1) {
-                                    checkRunId = run.id;
+                                if ((yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }))).data.findIndex((annotation) => annotation.message.includes(searchToken)) !== -1) {
+                                    jobId = job.id;
                                     break;
                                 }
                             }
                             catch (e) {
-                                core.info(`::debug::Error Fetching CheckRun ${run.id}: ${e}`);
+                                core.info(`::debug::Error Fetching Job ${job.id}: ${e}`);
                             }
                         }
                     }
-                    else if (checkRuns[0]) {
-                        checkRunId = checkRuns[0].id;
-                        core.info(`Current Check Run: ${checkRunId}`);
+                    else if (workflowResponse.jobs[0]) {
+                        jobId = workflowResponse.jobs[0].id;
                     }
                     else {
-                        throw `Unable to resolve GitHub Check Run`;
+                        throw `Unable to resolve GitHub Job`;
                     }
+                    core.info(`Current Job: ${jobId}`);
                 }
                 else {
-                    throw `Fetching octokit.checks.listForRef(${ref}) returned no results`;
+                    throw `Fetching octokit.actions.getWorkflowRun(${process.env.GITHUB_RUN_ID}) returned no results`;
                 }
             }
             catch (e) {
-                core.info(`::error::Error resolving GitHub Check Run: ${e}`);
+                core.info(`::error::Unable to resolve GitHub Job: ${e}`);
             }
         }
         else {
-            core.info(`::debug::Not in GitHub Action Context, Skipping Check Run Resolution`);
+            core.info(`::debug::Not in GitHub Action Context, Skipping Job Resolution`);
         }
-        return checkRunId;
+        return jobId;
     });
 }
 function annotateLintIssues(issues, checkRunId) {

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -2505,7 +2505,7 @@ exports.toCommandValue = toCommandValue;
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
 var rng = __webpack_require__(139);
-var bytesToUuid = __webpack_require__(105);
+var bytesToUuid = __webpack_require__(722);
 
 // **`v1()` - Generate time-based UUID**
 //
@@ -3769,38 +3769,7 @@ var _default = version;
 exports.default = _default;
 
 /***/ }),
-/* 105 */
-/***/ (function(module) {
-
-/**
- * Convert array of 16 byte values to UUID string format of the form:
- * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
- */
-var byteToHex = [];
-for (var i = 0; i < 256; ++i) {
-  byteToHex[i] = (i + 0x100).toString(16).substr(1);
-}
-
-function bytesToUuid(buf, offset) {
-  var i = offset || 0;
-  var bth = byteToHex;
-  // join used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
-  return ([
-    bth[buf[i++]], bth[buf[i++]],
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]], '-',
-    bth[buf[i++]], bth[buf[i++]],
-    bth[buf[i++]], bth[buf[i++]],
-    bth[buf[i++]], bth[buf[i++]]
-  ]).join('');
-}
-
-module.exports = bytesToUuid;
-
-
-/***/ }),
+/* 105 */,
 /* 106 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -6728,7 +6697,8 @@ const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const tmp_1 = __webpack_require__(150);
 const util_1 = __webpack_require__(669);
-const cache_1 = __webpack_require__(722);
+const uuid_1 = __webpack_require__(930);
+const cache_1 = __webpack_require__(913);
 const install_1 = __webpack_require__(655);
 const version_1 = __webpack_require__(52);
 const execShellCommand = util_1.promisify(child_process_1.exec);
@@ -6797,6 +6767,8 @@ function fetchPatch() {
 function prepareEnv() {
     return __awaiter(this, void 0, void 0, function* () {
         const startedAt = Date.now();
+        // Resolve Check Run ID
+        const resolveCheckRunIdPromise = resolveCheckRunId();
         // Prepare cache, lint and go in parallel.
         const restoreCachePromise = cache_1.restoreCache();
         const prepareLintPromise = prepareLint();
@@ -6806,8 +6778,9 @@ function prepareEnv() {
         yield installGoPromise;
         yield restoreCachePromise;
         const patchPath = yield patchPromise;
+        const checkRunId = yield resolveCheckRunIdPromise;
         core.info(`Prepared env in ${Date.now() - startedAt}ms`);
-        return { lintPath, patchPath };
+        return { lintPath, patchPath, checkRunId };
     });
 }
 var LintSeverity;
@@ -6861,26 +6834,78 @@ const logLintIssues = (issues) => {
         core.info(`${header} ${pos} - ${issue.Text} (${issue.FromLinter})`);
     });
 };
-function annotateLintIssues(issues) {
-    var _a;
+function resolveCheckRunId() {
+    var _a, _b, _c;
     return __awaiter(this, void 0, void 0, function* () {
-        if (!issues.length) {
+        let checkRunId = -1;
+        if (process.env.GITHUB_ACTIONS === `true`) {
+            try {
+                const searchToken = uuid_1.v4();
+                core.info(`::warning::Resolving GitHub CheckRunID (${searchToken})`);
+                const ctx = github.context;
+                const ref = (_a = ctx.payload.after) !== null && _a !== void 0 ? _a : ctx.sha;
+                const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
+                const { data: checkRunsResponse } = yield octokit.checks
+                    .listForRef(Object.assign(Object.assign({}, ctx.repo), { ref, status: `in_progress`, filter: `latest` }))
+                    .catch((e) => {
+                    throw `Unable to fetch Check Run List: ${e}`;
+                });
+                if (checkRunsResponse.check_runs.length > 0) {
+                    let checkRuns = checkRunsResponse.check_runs;
+                    if (checkRuns.length > 1) {
+                        checkRuns = (_b = checkRuns.filter((run) => run.name.includes(ctx.job))) !== null && _b !== void 0 ? _b : checkRuns;
+                    }
+                    if (checkRuns.length > 1) {
+                        checkRuns = (_c = checkRuns.filter((run) => run.output.annotations_count > 0)) !== null && _c !== void 0 ? _c : checkRuns;
+                    }
+                    if (checkRuns.length > 1) {
+                        for (const run of checkRuns) {
+                            try {
+                                if ((yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: run.id }))).data.findIndex((annotation) => annotation.message.includes(searchToken)) !== -1) {
+                                    checkRunId = run.id;
+                                    break;
+                                }
+                            }
+                            catch (e) {
+                                core.info(`::debug::Error Fetching CheckRun ${run.id}: ${e}`);
+                            }
+                        }
+                    }
+                    else if (checkRuns[0]) {
+                        checkRunId = checkRuns[0].id;
+                        core.info(`Current Check Run is: ${checkRunId}`);
+                    }
+                    else {
+                        throw `Unable to resolve GitHub Check Run`;
+                    }
+                }
+                else {
+                    throw `Fetching octokit.checks.listForRef(${ref}) returned no results`;
+                }
+            }
+            catch (e) {
+                core.info(`::error::Error resolving GitHub Check Run: ${e}`);
+            }
+        }
+        else {
+            core.info(`::debug::Not in GitHub Action Context, Skipping Check Run Resolution`);
+        }
+        return checkRunId;
+    });
+}
+function annotateLintIssues(issues, checkRunId) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (checkRunId === -1 || !issues.length) {
             return;
         }
-        const ctx = github.context;
-        const ref = ctx.payload.after;
-        const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
-        const checkRunsPromise = octokit.checks
-            .listForRef(Object.assign(Object.assign({}, ctx.repo), { ref, status: "in_progress" }))
-            .catch((e) => {
-            throw `Error getting Check Run Data: ${e}`;
-        });
         const chunkSize = 50;
         const issueCounts = {
             notice: 0,
             warning: 0,
             failure: 0,
         };
+        const ctx = github.context;
+        const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
         const githubAnnotations = issues.map((issue) => {
             // If/when we transition to comments, we would build the request structure here
             const annotation = {
@@ -6914,22 +6939,11 @@ function annotateLintIssues(issues) {
             }
             return annotation;
         });
-        let checkRun;
-        const { data: checkRunsResponse } = yield checkRunsPromise;
-        if (checkRunsResponse.check_runs.length === 0) {
-            throw `octokit.checks.listForRef(${ref}) returned no results`;
-        }
-        else {
-            checkRun = checkRunsResponse.check_runs.find((run) => run.name.includes(`Lint`));
-        }
-        if (!(checkRun === null || checkRun === void 0 ? void 0 : checkRun.id)) {
-            throw `Could not find current check run`;
-        }
-        const title = (_a = checkRun.output.title) !== null && _a !== void 0 ? _a : `GolangCI-Lint`;
+        const title = `GolangCI-Lint`;
         const summary = `There are {issueCounts.failure} failures, {issueCounts.wairning} warnings, and {issueCounts.notice} notices.`;
         Array.from({ length: Math.ceil(githubAnnotations.length / chunkSize) }, (v, i) => githubAnnotations.slice(i * chunkSize, i * chunkSize + chunkSize)).forEach((annotations) => {
             octokit.checks
-                .update(Object.assign(Object.assign({}, ctx.repo), { check_run_id: checkRun === null || checkRun === void 0 ? void 0 : checkRun.id, output: {
+                .update(Object.assign(Object.assign({}, ctx.repo), { check_run_id: checkRunId, output: {
                     title,
                     summary,
                     annotations,
@@ -6971,14 +6985,14 @@ const printOutput = (res) => {
         core.info(res.stderr);
     }
 };
-function printLintOutput(res) {
+function printLintOutput(res, checkRunId) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         let lintOutput;
         const exit_code = (_a = res.code) !== null && _a !== void 0 ? _a : 0;
         try {
-            try {
-                if (res.stdout) {
+            if (res.stdout) {
+                try {
                     // This object contains other information, such as errors and the active linters
                     // TODO: Should we do something with that data?
                     lintOutput = parseOutput(res.stdout);
@@ -6990,7 +7004,7 @@ function printLintOutput(res) {
                             // TODO: When we are ready to handle these as Comments, instead of Annotations, we would place that logic here
                             /* falls through */
                             case `push`:
-                                yield annotateLintIssues(lintOutput.Issues);
+                                yield annotateLintIssues(lintOutput.Issues, checkRunId);
                                 break;
                             default:
                                 // At this time, other events are not supported
@@ -6998,21 +7012,19 @@ function printLintOutput(res) {
                         }
                     }
                 }
-            }
-            catch (e) {
-                throw `there was an error processing golangci-lint output: ${e}`;
+                catch (e) {
+                    throw `there was an error processing golangci-lint output: ${e}`;
+                }
             }
             if (res.stderr) {
                 core.info(res.stderr);
             }
             if (exit_code === 1) {
-                if (lintOutput) {
-                    if (hasFailingIssues(lintOutput.Issues)) {
-                        throw `issues found`;
-                    }
-                }
-                else {
+                if (!lintOutput) {
                     throw `unexpected state, golangci-lint exited with 1, but provided no lint output`;
+                }
+                if (hasFailingIssues(lintOutput.Issues)) {
+                    throw `issues found`;
                 }
             }
             else if (exit_code > 1) {
@@ -7025,7 +7037,7 @@ function printLintOutput(res) {
         return core.info(`golangci-lint found no blocking issues`);
     });
 }
-function runLint(lintPath, patchPath) {
+function runLint(lintPath, patchPath, checkRunId) {
     return __awaiter(this, void 0, void 0, function* () {
         const debug = core.getInput(`debug`);
         if (debug.split(`,`).includes(`cache`)) {
@@ -7075,12 +7087,12 @@ function runLint(lintPath, patchPath) {
         const startedAt = Date.now();
         try {
             const res = yield execShellCommand(cmd, cmdArgs);
-            yield printLintOutput(res);
+            yield printLintOutput(res, checkRunId);
         }
         catch (exc) {
             // This logging passes issues to GitHub annotations but comments can be more convenient for some users.
             // TODO: support reviewdog or leaving comments by GitHub API.
-            yield printLintOutput(exc);
+            yield printLintOutput(exc, checkRunId);
         }
         core.info(`Ran golangci-lint in ${Date.now() - startedAt}ms`);
     });
@@ -7088,9 +7100,9 @@ function runLint(lintPath, patchPath) {
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const { lintPath, patchPath } = yield core.group(`prepare environment`, prepareEnv);
+            const { lintPath, patchPath, checkRunId } = yield core.group(`prepare environment`, prepareEnv);
             core.addPath(path.dirname(lintPath));
-            yield core.group(`run golangci-lint`, () => runLint(lintPath, patchPath));
+            yield core.group(`run golangci-lint`, () => runLint(lintPath, patchPath, checkRunId));
         }
         catch (error) {
             core.error(`Failed to run: ${error}, ${error.stack}`);
@@ -52351,183 +52363,34 @@ __webpack_require__(71);
 /* 720 */,
 /* 721 */,
 /* 722 */
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(module) {
 
-"use strict";
+/**
+ * Convert array of 16 byte values to UUID string format of the form:
+ * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+ */
+var byteToHex = [];
+for (var i = 0; i < 256; ++i) {
+  byteToHex[i] = (i + 0x100).toString(16).substr(1);
+}
 
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.saveCache = exports.restoreCache = void 0;
-const cache = __importStar(__webpack_require__(638));
-const core = __importStar(__webpack_require__(470));
-const crypto = __importStar(__webpack_require__(417));
-const fs = __importStar(__webpack_require__(747));
-const path_1 = __importDefault(__webpack_require__(622));
-const constants_1 = __webpack_require__(196);
-const utils = __importStar(__webpack_require__(443));
-function checksumFile(hashName, path) {
-    return new Promise((resolve, reject) => {
-        const hash = crypto.createHash(hashName);
-        const stream = fs.createReadStream(path);
-        stream.on("error", (err) => reject(err));
-        stream.on("data", (chunk) => hash.update(chunk));
-        stream.on("end", () => resolve(hash.digest("hex")));
-    });
+function bytesToUuid(buf, offset) {
+  var i = offset || 0;
+  var bth = byteToHex;
+  // join used to fix memory issue caused by concatenation: https://bugs.chromium.org/p/v8/issues/detail?id=3175#c4
+  return ([
+    bth[buf[i++]], bth[buf[i++]],
+    bth[buf[i++]], bth[buf[i++]], '-',
+    bth[buf[i++]], bth[buf[i++]], '-',
+    bth[buf[i++]], bth[buf[i++]], '-',
+    bth[buf[i++]], bth[buf[i++]], '-',
+    bth[buf[i++]], bth[buf[i++]],
+    bth[buf[i++]], bth[buf[i++]],
+    bth[buf[i++]], bth[buf[i++]]
+  ]).join('');
 }
-const pathExists = (path) => __awaiter(void 0, void 0, void 0, function* () { return !!(yield fs.promises.stat(path).catch(() => false)); });
-const getLintCacheDir = () => {
-    return path_1.default.resolve(`${process.env.HOME}/.cache/golangci-lint`);
-};
-const getCacheDirs = () => {
-    // Not existing dirs are ok here: it works.
-    const skipPkgCache = core.getInput(`skip-pkg-cache`, { required: true }).trim();
-    const skipBuildCache = core.getInput(`skip-build-cache`, { required: true }).trim();
-    const dirs = [getLintCacheDir()];
-    if (skipBuildCache.toLowerCase() == "true") {
-        core.info(`Omitting ~/.cache/go-build from cache directories`);
-    }
-    else {
-        dirs.push(path_1.default.resolve(`${process.env.HOME}/.cache/go-build`));
-    }
-    if (skipPkgCache.toLowerCase() == "true") {
-        core.info(`Omitting ~/go/pkg from cache directories`);
-    }
-    else {
-        dirs.push(path_1.default.resolve(`${process.env.HOME}/go/pkg`));
-    }
-    return dirs;
-};
-const getIntervalKey = (invalidationIntervalDays) => {
-    const now = new Date();
-    const secondsSinceEpoch = now.getTime() / 1000;
-    const intervalNumber = Math.floor(secondsSinceEpoch / (invalidationIntervalDays * 86400));
-    return intervalNumber.toString();
-};
-function buildCacheKeys() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const keys = [];
-        let cacheKey = `golangci-lint.cache-`;
-        keys.push(cacheKey);
-        // Periodically invalidate a cache because a new code being added.
-        // TODO: configure it via inputs.
-        cacheKey += `${getIntervalKey(7)}-`;
-        keys.push(cacheKey);
-        if (yield pathExists(`go.mod`)) {
-            // Add checksum to key to invalidate a cache when dependencies change.
-            cacheKey += yield checksumFile(`sha1`, `go.mod`);
-        }
-        else {
-            cacheKey += `nogomod`;
-        }
-        keys.push(cacheKey);
-        return keys;
-    });
-}
-function restoreCache() {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (!utils.isValidEvent()) {
-            utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-            return;
-        }
-        const startedAt = Date.now();
-        const keys = yield buildCacheKeys();
-        const primaryKey = keys.pop();
-        const restoreKeys = keys.reverse();
-        // Tell golangci-lint to use our cache directory.
-        process.env.GOLANGCI_LINT_CACHE = getLintCacheDir();
-        if (!primaryKey) {
-            utils.logWarning(`Invalid primary key`);
-            return;
-        }
-        core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
-        try {
-            const cacheKey = yield cache.restoreCache(getCacheDirs(), primaryKey, restoreKeys);
-            if (!cacheKey) {
-                core.info(`Cache not found for input keys: ${[primaryKey, ...restoreKeys].join(", ")}`);
-                return;
-            }
-            // Store the matched cache key
-            utils.setCacheState(cacheKey);
-            core.info(`Restored cache for golangci-lint from key '${primaryKey}' in ${Date.now() - startedAt}ms`);
-        }
-        catch (error) {
-            if (error.name === cache.ValidationError.name) {
-                throw error;
-            }
-            else {
-                core.warning(error.message);
-            }
-        }
-    });
-}
-exports.restoreCache = restoreCache;
-function saveCache() {
-    return __awaiter(this, void 0, void 0, function* () {
-        // Validate inputs, this can cause task failure
-        if (!utils.isValidEvent()) {
-            utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
-            return;
-        }
-        const startedAt = Date.now();
-        const cacheDirs = getCacheDirs();
-        const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
-        if (!primaryKey) {
-            utils.logWarning(`Error retrieving key from state.`);
-            return;
-        }
-        const state = utils.getCacheState();
-        if (utils.isExactKeyMatch(primaryKey, state)) {
-            core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-            return;
-        }
-        try {
-            yield cache.saveCache(cacheDirs, primaryKey);
-            core.info(`Saved cache for golangci-lint from paths '${cacheDirs.join(`, `)}' in ${Date.now() - startedAt}ms`);
-        }
-        catch (error) {
-            if (error.name === cache.ValidationError.name) {
-                throw error;
-            }
-            else if (error.name === cache.ReserveCacheError.name) {
-                core.info(error.message);
-            }
-            else {
-                core.info(`[warning] ${error.message}`);
-            }
-        }
-    });
-}
-exports.saveCache = saveCache;
+
+module.exports = bytesToUuid;
 
 
 /***/ }),
@@ -55782,7 +55645,7 @@ var __createBinding;
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
 var rng = __webpack_require__(139);
-var bytesToUuid = __webpack_require__(105);
+var bytesToUuid = __webpack_require__(722);
 
 function v4(options, buf, offset) {
   var i = buf && offset || 0;
@@ -60629,7 +60492,187 @@ __exportStar(__webpack_require__(764), exports);
 /***/ }),
 /* 911 */,
 /* 912 */,
-/* 913 */,
+/* 913 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.saveCache = exports.restoreCache = void 0;
+const cache = __importStar(__webpack_require__(638));
+const core = __importStar(__webpack_require__(470));
+const crypto = __importStar(__webpack_require__(417));
+const fs = __importStar(__webpack_require__(747));
+const path_1 = __importDefault(__webpack_require__(622));
+const constants_1 = __webpack_require__(196);
+const utils = __importStar(__webpack_require__(443));
+function checksumFile(hashName, path) {
+    return new Promise((resolve, reject) => {
+        const hash = crypto.createHash(hashName);
+        const stream = fs.createReadStream(path);
+        stream.on("error", (err) => reject(err));
+        stream.on("data", (chunk) => hash.update(chunk));
+        stream.on("end", () => resolve(hash.digest("hex")));
+    });
+}
+const pathExists = (path) => __awaiter(void 0, void 0, void 0, function* () { return !!(yield fs.promises.stat(path).catch(() => false)); });
+const getLintCacheDir = () => {
+    return path_1.default.resolve(`${process.env.HOME}/.cache/golangci-lint`);
+};
+const getCacheDirs = () => {
+    // Not existing dirs are ok here: it works.
+    const skipPkgCache = core.getInput(`skip-pkg-cache`, { required: true }).trim();
+    const skipBuildCache = core.getInput(`skip-build-cache`, { required: true }).trim();
+    const dirs = [getLintCacheDir()];
+    if (skipBuildCache.toLowerCase() == "true") {
+        core.info(`Omitting ~/.cache/go-build from cache directories`);
+    }
+    else {
+        dirs.push(path_1.default.resolve(`${process.env.HOME}/.cache/go-build`));
+    }
+    if (skipPkgCache.toLowerCase() == "true") {
+        core.info(`Omitting ~/go/pkg from cache directories`);
+    }
+    else {
+        dirs.push(path_1.default.resolve(`${process.env.HOME}/go/pkg`));
+    }
+    return dirs;
+};
+const getIntervalKey = (invalidationIntervalDays) => {
+    const now = new Date();
+    const secondsSinceEpoch = now.getTime() / 1000;
+    const intervalNumber = Math.floor(secondsSinceEpoch / (invalidationIntervalDays * 86400));
+    return intervalNumber.toString();
+};
+function buildCacheKeys() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const keys = [];
+        let cacheKey = `golangci-lint.cache-`;
+        keys.push(cacheKey);
+        // Periodically invalidate a cache because a new code being added.
+        // TODO: configure it via inputs.
+        cacheKey += `${getIntervalKey(7)}-`;
+        keys.push(cacheKey);
+        if (yield pathExists(`go.mod`)) {
+            // Add checksum to key to invalidate a cache when dependencies change.
+            cacheKey += yield checksumFile(`sha1`, `go.mod`);
+        }
+        else {
+            cacheKey += `nogomod`;
+        }
+        keys.push(cacheKey);
+        return keys;
+    });
+}
+function restoreCache() {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!utils.isValidEvent()) {
+            utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
+            return;
+        }
+        const startedAt = Date.now();
+        const keys = yield buildCacheKeys();
+        const primaryKey = keys.pop();
+        const restoreKeys = keys.reverse();
+        // Tell golangci-lint to use our cache directory.
+        process.env.GOLANGCI_LINT_CACHE = getLintCacheDir();
+        if (!primaryKey) {
+            utils.logWarning(`Invalid primary key`);
+            return;
+        }
+        core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
+        try {
+            const cacheKey = yield cache.restoreCache(getCacheDirs(), primaryKey, restoreKeys);
+            if (!cacheKey) {
+                core.info(`Cache not found for input keys: ${[primaryKey, ...restoreKeys].join(", ")}`);
+                return;
+            }
+            // Store the matched cache key
+            utils.setCacheState(cacheKey);
+            core.info(`Restored cache for golangci-lint from key '${primaryKey}' in ${Date.now() - startedAt}ms`);
+        }
+        catch (error) {
+            if (error.name === cache.ValidationError.name) {
+                throw error;
+            }
+            else {
+                core.warning(error.message);
+            }
+        }
+    });
+}
+exports.restoreCache = restoreCache;
+function saveCache() {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Validate inputs, this can cause task failure
+        if (!utils.isValidEvent()) {
+            utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);
+            return;
+        }
+        const startedAt = Date.now();
+        const cacheDirs = getCacheDirs();
+        const primaryKey = core.getState(constants_1.State.CachePrimaryKey);
+        if (!primaryKey) {
+            utils.logWarning(`Error retrieving key from state.`);
+            return;
+        }
+        const state = utils.getCacheState();
+        if (utils.isExactKeyMatch(primaryKey, state)) {
+            core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
+            return;
+        }
+        try {
+            yield cache.saveCache(cacheDirs, primaryKey);
+            core.info(`Saved cache for golangci-lint from paths '${cacheDirs.join(`, `)}' in ${Date.now() - startedAt}ms`);
+        }
+        catch (error) {
+            if (error.name === cache.ValidationError.name) {
+                throw error;
+            }
+            else if (error.name === cache.ReserveCacheError.name) {
+                core.info(error.message);
+            }
+            else {
+                core.info(`[warning] ${error.message}`);
+            }
+        }
+    });
+}
+exports.saveCache = saveCache;
+
+
+/***/ }),
 /* 914 */,
 /* 915 */,
 /* 916 */,

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6867,6 +6867,10 @@ function resolveCheckRunId() {
                     if (workflowResponse.jobs.length > 1) {
                         const searchToken = uuid_1.v4();
                         core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`);
+                        yield ((ms) => {
+                            core.info(`resolveCheckRunId() Sleeping for ${ms / 1000} Seconds`);
+                            return new Promise((resolve) => setTimeout(resolve, ms));
+                        })(2 * 1000);
                         for (const job of workflowResponse.jobs) {
                             try {
                                 const { data: annotations } = yield octokit.checks.listAnnotations(Object.assign(Object.assign({}, ctx.repo), { check_run_id: job.id }));

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -42,6 +42,8 @@ module.exports =
 /******/ 		// Load entry module and return exports
 /******/ 		return __webpack_require__(131);
 /******/ 	};
+/******/ 	// initialize runtime
+/******/ 	runtime(__webpack_require__);
 /******/
 /******/ 	// run startup
 /******/ 	return startup();
@@ -6713,10 +6715,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.postRun = exports.run = void 0;
 const core = __importStar(__webpack_require__(470));
 const github = __importStar(__webpack_require__(469));
+const ansi_styles_1 = __importDefault(__webpack_require__(663));
 const child_process_1 = __webpack_require__(129);
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
@@ -6804,6 +6810,159 @@ function prepareEnv() {
         return { lintPath, patchPath };
     });
 }
+var LintSeverity;
+(function (LintSeverity) {
+    LintSeverity[LintSeverity["notice"] = 0] = "notice";
+    LintSeverity[LintSeverity["warning"] = 1] = "warning";
+    LintSeverity[LintSeverity["failure"] = 2] = "failure";
+})(LintSeverity || (LintSeverity = {}));
+const DefaultFailureSeverity = LintSeverity.notice;
+const parseOutput = (json) => {
+    const severityMap = {
+        info: `notice`,
+        notice: `notice`,
+        minor: `warning`,
+        warning: `warning`,
+        error: `failure`,
+        major: `failure`,
+        critical: `failure`,
+        blocker: `failure`,
+        failure: `failure`,
+    };
+    const lintOutput = JSON.parse(json);
+    if (!lintOutput.Report) {
+        throw `golangci-lint returned invalid json`;
+    }
+    if (lintOutput.Issues.length) {
+        lintOutput.Issues = lintOutput.Issues.filter((issue) => issue.Severity !== `ignore`).map((issue) => {
+            const Severity = issue.Severity.toLowerCase();
+            issue.Severity = severityMap[`${Severity}`] ? severityMap[`${Severity}`] : `failure`;
+            return issue;
+        });
+    }
+    return lintOutput;
+};
+const logLintIssues = (issues) => {
+    issues.forEach((issue) => {
+        let header = `${ansi_styles_1.default.red.open}${ansi_styles_1.default.bold.open}Lint Error:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.red.close}`;
+        if (issue.Severity === `warning`) {
+            header = `${ansi_styles_1.default.yellow.open}${ansi_styles_1.default.bold.open}Lint Warning:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.yellow.close}`;
+        }
+        else if (issue.Severity === `notice`) {
+            header = `${ansi_styles_1.default.cyan.open}${ansi_styles_1.default.bold.open}Lint Notice:${ansi_styles_1.default.bold.close}${ansi_styles_1.default.cyan.close}`;
+        }
+        let pos = `${issue.Pos.Filename}:${issue.Pos.Line}`;
+        if (issue.LineRange !== undefined) {
+            pos += `-${issue.LineRange.To}`;
+        }
+        else if (issue.Pos.Column) {
+            pos += `:${issue.Pos.Column}`;
+        }
+        core.info(`${header} ${pos} - ${issue.Text} (${issue.FromLinter})`);
+    });
+};
+function annotateLintIssues(issues) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!issues.length) {
+            return;
+        }
+        const ctx = github.context;
+        const ref = ctx.payload.after;
+        const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
+        const checkRunsPromise = octokit.checks
+            .listForRef(Object.assign(Object.assign({}, ctx.repo), { ref, status: "in_progress" }))
+            .catch((e) => {
+            throw `Error getting Check Run Data: ${e}`;
+        });
+        const chunkSize = 50;
+        const issueCounts = {
+            notice: 0,
+            warning: 0,
+            failure: 0,
+        };
+        const githubAnnotations = issues.map((issue) => {
+            // If/when we transition to comments, we would build the request structure here
+            const annotation = {
+                path: issue.Pos.Filename,
+                start_line: issue.Pos.Line,
+                end_line: issue.Pos.Line,
+                title: issue.FromLinter,
+                message: issue.Text,
+                annotation_level: issue.Severity,
+            };
+            issueCounts[issue.Severity]++;
+            if (issue.LineRange !== undefined) {
+                annotation.end_line = issue.LineRange.To;
+            }
+            else if (issue.Pos.Column) {
+                annotation.start_column = issue.Pos.Column;
+                annotation.end_column = issue.Pos.Column;
+            }
+            if (issue.Replacement !== null) {
+                let replacement = ``;
+                if (issue.Replacement.Inline) {
+                    replacement =
+                        issue.SourceLines[0].slice(0, issue.Replacement.Inline.StartCol) +
+                            issue.Replacement.Inline.NewString +
+                            issue.SourceLines[0].slice(issue.Replacement.Inline.StartCol + issue.Replacement.Inline.Length);
+                }
+                else if (issue.Replacement.NewLines) {
+                    replacement = issue.Replacement.NewLines.join("\n");
+                }
+                annotation.raw_details = "```suggestion\n" + replacement + "\n```";
+            }
+            return annotation;
+        });
+        let checkRun;
+        const { data: checkRunsResponse } = yield checkRunsPromise;
+        if (checkRunsResponse.check_runs.length === 0) {
+            throw `octokit.checks.listForRef(${ref}) returned no results`;
+        }
+        else {
+            checkRun = checkRunsResponse.check_runs.find((run) => run.name.includes(`Lint`));
+        }
+        if (!(checkRun === null || checkRun === void 0 ? void 0 : checkRun.id)) {
+            throw `Could not find current check run`;
+        }
+        const title = (_a = checkRun.output.title) !== null && _a !== void 0 ? _a : `GolangCI-Lint`;
+        const summary = `There are {issueCounts.failure} failures, {issueCounts.wairning} warnings, and {issueCounts.notice} notices.`;
+        Array.from({ length: Math.ceil(githubAnnotations.length / chunkSize) }, (v, i) => githubAnnotations.slice(i * chunkSize, i * chunkSize + chunkSize)).forEach((annotations) => {
+            octokit.checks
+                .update(Object.assign(Object.assign({}, ctx.repo), { check_run_id: checkRun === null || checkRun === void 0 ? void 0 : checkRun.id, output: {
+                    title,
+                    summary,
+                    annotations,
+                } }))
+                .catch((e) => {
+                throw `Error patching Check Run Data (annotations): ${e}`;
+            });
+        });
+    });
+}
+const hasFailingIssues = (issues) => {
+    // If the user input is not a valid Severity Level, this will be -1, and any issue will fail
+    const userFailureSeverity = core.getInput(`failure-severity`).toLowerCase();
+    let failureSeverity = DefaultFailureSeverity;
+    if (userFailureSeverity) {
+        failureSeverity = Object.values(LintSeverity).indexOf(userFailureSeverity);
+    }
+    if (failureSeverity < 0) {
+        core.info(`::warning::failure-severity must be one of (${Object.keys(LintSeverity).join(" | ")}). "${userFailureSeverity}" not supported, using default (${LintSeverity[DefaultFailureSeverity]})`);
+        failureSeverity = DefaultFailureSeverity;
+    }
+    if (issues.length) {
+        if (failureSeverity <= 0) {
+            return true;
+        }
+        for (const issue of issues) {
+            if (failureSeverity <= LintSeverity[issue.Severity]) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
 const printOutput = (res) => {
     if (res.stdout) {
         core.info(res.stdout);
@@ -6812,6 +6971,60 @@ const printOutput = (res) => {
         core.info(res.stderr);
     }
 };
+function printLintOutput(res) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function* () {
+        let lintOutput;
+        const exit_code = (_a = res.code) !== null && _a !== void 0 ? _a : 0;
+        try {
+            try {
+                if (res.stdout) {
+                    // This object contains other information, such as errors and the active linters
+                    // TODO: Should we do something with that data?
+                    lintOutput = parseOutput(res.stdout);
+                    if (lintOutput.Issues.length) {
+                        logLintIssues(lintOutput.Issues);
+                        // We can only Annotate (or Comment) on Push or Pull Request
+                        switch (github.context.eventName) {
+                            case `pull_request`:
+                            // TODO: When we are ready to handle these as Comments, instead of Annotations, we would place that logic here
+                            /* falls through */
+                            case `push`:
+                                yield annotateLintIssues(lintOutput.Issues);
+                                break;
+                            default:
+                                // At this time, other events are not supported
+                                break;
+                        }
+                    }
+                }
+            }
+            catch (e) {
+                throw `there was an error processing golangci-lint output: ${e}`;
+            }
+            if (res.stderr) {
+                core.info(res.stderr);
+            }
+            if (exit_code === 1) {
+                if (lintOutput) {
+                    if (hasFailingIssues(lintOutput.Issues)) {
+                        throw `issues found`;
+                    }
+                }
+                else {
+                    throw `unexpected state, golangci-lint exited with 1, but provided no lint output`;
+                }
+            }
+            else if (exit_code > 1) {
+                throw `golangci-lint exit with code ${exit_code}`;
+            }
+        }
+        catch (e) {
+            return core.setFailed(`${e}`);
+        }
+        return core.info(`golangci-lint found no blocking issues`);
+    });
+}
 function runLint(lintPath, patchPath) {
     return __awaiter(this, void 0, void 0, function* () {
         const debug = core.getInput(`debug`);
@@ -6832,7 +7045,7 @@ function runLint(lintPath, patchPath) {
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }
-        addedArgs.push(`--out-format=github-actions`);
+        addedArgs.push(`--out-format=json`);
         if (patchPath) {
             if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
                 throw new Error(`please, don't specify manually --new* args when requesting only new issues`);
@@ -6862,19 +7075,12 @@ function runLint(lintPath, patchPath) {
         const startedAt = Date.now();
         try {
             const res = yield execShellCommand(cmd, cmdArgs);
-            printOutput(res);
-            core.info(`golangci-lint found no issues`);
+            yield printLintOutput(res);
         }
         catch (exc) {
             // This logging passes issues to GitHub annotations but comments can be more convenient for some users.
             // TODO: support reviewdog or leaving comments by GitHub API.
-            printOutput(exc);
-            if (exc.code === 1) {
-                core.setFailed(`issues found`);
-            }
-            else {
-                core.setFailed(`golangci-lint exit with code ${exc.code}`);
-            }
+            yield printLintOutput(exc);
         }
         core.info(`Ran golangci-lint in ${Date.now() - startedAt}ms`);
     });
@@ -8824,7 +9030,109 @@ exports.downloadCacheStorageSDK = downloadCacheStorageSDK;
 /***/ }),
 /* 258 */,
 /* 259 */,
-/* 260 */,
+/* 260 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const conversions = __webpack_require__(600);
+
+/*
+	This function routes a model to all other models.
+
+	all functions that are routed have a property `.conversion` attached
+	to the returned synthetic function. This property is an array
+	of strings, each with the steps in between the 'from' and 'to'
+	color models (inclusive).
+
+	conversions that are not possible simply are not included.
+*/
+
+function buildGraph() {
+	const graph = {};
+	// https://jsperf.com/object-keys-vs-for-in-with-closure/3
+	const models = Object.keys(conversions);
+
+	for (let len = models.length, i = 0; i < len; i++) {
+		graph[models[i]] = {
+			// http://jsperf.com/1-vs-infinity
+			// micro-opt, but this is simple.
+			distance: -1,
+			parent: null
+		};
+	}
+
+	return graph;
+}
+
+// https://en.wikipedia.org/wiki/Breadth-first_search
+function deriveBFS(fromModel) {
+	const graph = buildGraph();
+	const queue = [fromModel]; // Unshift -> queue -> pop
+
+	graph[fromModel].distance = 0;
+
+	while (queue.length) {
+		const current = queue.pop();
+		const adjacents = Object.keys(conversions[current]);
+
+		for (let len = adjacents.length, i = 0; i < len; i++) {
+			const adjacent = adjacents[i];
+			const node = graph[adjacent];
+
+			if (node.distance === -1) {
+				node.distance = graph[current].distance + 1;
+				node.parent = current;
+				queue.unshift(adjacent);
+			}
+		}
+	}
+
+	return graph;
+}
+
+function link(from, to) {
+	return function (args) {
+		return to(from(args));
+	};
+}
+
+function wrapConversion(toModel, graph) {
+	const path = [graph[toModel].parent, toModel];
+	let fn = conversions[graph[toModel].parent][toModel];
+
+	let cur = graph[toModel].parent;
+	while (graph[cur].parent) {
+		path.unshift(graph[cur].parent);
+		fn = link(conversions[graph[cur].parent][cur], fn);
+		cur = graph[cur].parent;
+	}
+
+	fn.conversion = path;
+	return fn;
+}
+
+module.exports = function (fromModel) {
+	const graph = deriveBFS(fromModel);
+	const conversion = {};
+
+	const models = Object.keys(graph);
+	for (let len = models.length, i = 0; i < len; i++) {
+		const toModel = models[i];
+		const node = graph[toModel];
+
+		if (node.parent === null) {
+			// No possible conversion, or this node is the source model.
+			continue;
+		}
+
+		conversion[toModel] = wrapConversion(toModel, graph);
+	}
+
+	return conversion;
+};
+
+
+
+/***/ }),
 /* 261 */,
 /* 262 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -36624,7 +36932,393 @@ exports.endpoint = endpoint;
 /* 386 */,
 /* 387 */,
 /* 388 */,
-/* 389 */,
+/* 389 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+// Generated by CoffeeScript 1.12.7
+(function() {
+  "use strict";
+  var bom, defaults, events, isEmpty, processItem, processors, sax, setImmediate,
+    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+    extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+    hasProp = {}.hasOwnProperty;
+
+  sax = __webpack_require__(645);
+
+  events = __webpack_require__(614);
+
+  bom = __webpack_require__(210);
+
+  processors = __webpack_require__(350);
+
+  setImmediate = __webpack_require__(343).setImmediate;
+
+  defaults = __webpack_require__(791).defaults;
+
+  isEmpty = function(thing) {
+    return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
+  };
+
+  processItem = function(processors, item, key) {
+    var i, len, process;
+    for (i = 0, len = processors.length; i < len; i++) {
+      process = processors[i];
+      item = process(item, key);
+    }
+    return item;
+  };
+
+  exports.Parser = (function(superClass) {
+    extend(Parser, superClass);
+
+    function Parser(opts) {
+      this.parseStringPromise = bind(this.parseStringPromise, this);
+      this.parseString = bind(this.parseString, this);
+      this.reset = bind(this.reset, this);
+      this.assignOrPush = bind(this.assignOrPush, this);
+      this.processAsync = bind(this.processAsync, this);
+      var key, ref, value;
+      if (!(this instanceof exports.Parser)) {
+        return new exports.Parser(opts);
+      }
+      this.options = {};
+      ref = defaults["0.2"];
+      for (key in ref) {
+        if (!hasProp.call(ref, key)) continue;
+        value = ref[key];
+        this.options[key] = value;
+      }
+      for (key in opts) {
+        if (!hasProp.call(opts, key)) continue;
+        value = opts[key];
+        this.options[key] = value;
+      }
+      if (this.options.xmlns) {
+        this.options.xmlnskey = this.options.attrkey + "ns";
+      }
+      if (this.options.normalizeTags) {
+        if (!this.options.tagNameProcessors) {
+          this.options.tagNameProcessors = [];
+        }
+        this.options.tagNameProcessors.unshift(processors.normalize);
+      }
+      this.reset();
+    }
+
+    Parser.prototype.processAsync = function() {
+      var chunk, err;
+      try {
+        if (this.remaining.length <= this.options.chunkSize) {
+          chunk = this.remaining;
+          this.remaining = '';
+          this.saxParser = this.saxParser.write(chunk);
+          return this.saxParser.close();
+        } else {
+          chunk = this.remaining.substr(0, this.options.chunkSize);
+          this.remaining = this.remaining.substr(this.options.chunkSize, this.remaining.length);
+          this.saxParser = this.saxParser.write(chunk);
+          return setImmediate(this.processAsync);
+        }
+      } catch (error1) {
+        err = error1;
+        if (!this.saxParser.errThrown) {
+          this.saxParser.errThrown = true;
+          return this.emit(err);
+        }
+      }
+    };
+
+    Parser.prototype.assignOrPush = function(obj, key, newValue) {
+      if (!(key in obj)) {
+        if (!this.options.explicitArray) {
+          return obj[key] = newValue;
+        } else {
+          return obj[key] = [newValue];
+        }
+      } else {
+        if (!(obj[key] instanceof Array)) {
+          obj[key] = [obj[key]];
+        }
+        return obj[key].push(newValue);
+      }
+    };
+
+    Parser.prototype.reset = function() {
+      var attrkey, charkey, ontext, stack;
+      this.removeAllListeners();
+      this.saxParser = sax.parser(this.options.strict, {
+        trim: false,
+        normalize: false,
+        xmlns: this.options.xmlns
+      });
+      this.saxParser.errThrown = false;
+      this.saxParser.onerror = (function(_this) {
+        return function(error) {
+          _this.saxParser.resume();
+          if (!_this.saxParser.errThrown) {
+            _this.saxParser.errThrown = true;
+            return _this.emit("error", error);
+          }
+        };
+      })(this);
+      this.saxParser.onend = (function(_this) {
+        return function() {
+          if (!_this.saxParser.ended) {
+            _this.saxParser.ended = true;
+            return _this.emit("end", _this.resultObject);
+          }
+        };
+      })(this);
+      this.saxParser.ended = false;
+      this.EXPLICIT_CHARKEY = this.options.explicitCharkey;
+      this.resultObject = null;
+      stack = [];
+      attrkey = this.options.attrkey;
+      charkey = this.options.charkey;
+      this.saxParser.onopentag = (function(_this) {
+        return function(node) {
+          var key, newValue, obj, processedKey, ref;
+          obj = {};
+          obj[charkey] = "";
+          if (!_this.options.ignoreAttrs) {
+            ref = node.attributes;
+            for (key in ref) {
+              if (!hasProp.call(ref, key)) continue;
+              if (!(attrkey in obj) && !_this.options.mergeAttrs) {
+                obj[attrkey] = {};
+              }
+              newValue = _this.options.attrValueProcessors ? processItem(_this.options.attrValueProcessors, node.attributes[key], key) : node.attributes[key];
+              processedKey = _this.options.attrNameProcessors ? processItem(_this.options.attrNameProcessors, key) : key;
+              if (_this.options.mergeAttrs) {
+                _this.assignOrPush(obj, processedKey, newValue);
+              } else {
+                obj[attrkey][processedKey] = newValue;
+              }
+            }
+          }
+          obj["#name"] = _this.options.tagNameProcessors ? processItem(_this.options.tagNameProcessors, node.name) : node.name;
+          if (_this.options.xmlns) {
+            obj[_this.options.xmlnskey] = {
+              uri: node.uri,
+              local: node.local
+            };
+          }
+          return stack.push(obj);
+        };
+      })(this);
+      this.saxParser.onclosetag = (function(_this) {
+        return function() {
+          var cdata, emptyStr, key, node, nodeName, obj, objClone, old, s, xpath;
+          obj = stack.pop();
+          nodeName = obj["#name"];
+          if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
+            delete obj["#name"];
+          }
+          if (obj.cdata === true) {
+            cdata = obj.cdata;
+            delete obj.cdata;
+          }
+          s = stack[stack.length - 1];
+          if (obj[charkey].match(/^\s*$/) && !cdata) {
+            emptyStr = obj[charkey];
+            delete obj[charkey];
+          } else {
+            if (_this.options.trim) {
+              obj[charkey] = obj[charkey].trim();
+            }
+            if (_this.options.normalize) {
+              obj[charkey] = obj[charkey].replace(/\s{2,}/g, " ").trim();
+            }
+            obj[charkey] = _this.options.valueProcessors ? processItem(_this.options.valueProcessors, obj[charkey], nodeName) : obj[charkey];
+            if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
+              obj = obj[charkey];
+            }
+          }
+          if (isEmpty(obj)) {
+            obj = _this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr;
+          }
+          if (_this.options.validator != null) {
+            xpath = "/" + ((function() {
+              var i, len, results;
+              results = [];
+              for (i = 0, len = stack.length; i < len; i++) {
+                node = stack[i];
+                results.push(node["#name"]);
+              }
+              return results;
+            })()).concat(nodeName).join("/");
+            (function() {
+              var err;
+              try {
+                return obj = _this.options.validator(xpath, s && s[nodeName], obj);
+              } catch (error1) {
+                err = error1;
+                return _this.emit("error", err);
+              }
+            })();
+          }
+          if (_this.options.explicitChildren && !_this.options.mergeAttrs && typeof obj === 'object') {
+            if (!_this.options.preserveChildrenOrder) {
+              node = {};
+              if (_this.options.attrkey in obj) {
+                node[_this.options.attrkey] = obj[_this.options.attrkey];
+                delete obj[_this.options.attrkey];
+              }
+              if (!_this.options.charsAsChildren && _this.options.charkey in obj) {
+                node[_this.options.charkey] = obj[_this.options.charkey];
+                delete obj[_this.options.charkey];
+              }
+              if (Object.getOwnPropertyNames(obj).length > 0) {
+                node[_this.options.childkey] = obj;
+              }
+              obj = node;
+            } else if (s) {
+              s[_this.options.childkey] = s[_this.options.childkey] || [];
+              objClone = {};
+              for (key in obj) {
+                if (!hasProp.call(obj, key)) continue;
+                objClone[key] = obj[key];
+              }
+              s[_this.options.childkey].push(objClone);
+              delete obj["#name"];
+              if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
+                obj = obj[charkey];
+              }
+            }
+          }
+          if (stack.length > 0) {
+            return _this.assignOrPush(s, nodeName, obj);
+          } else {
+            if (_this.options.explicitRoot) {
+              old = obj;
+              obj = {};
+              obj[nodeName] = old;
+            }
+            _this.resultObject = obj;
+            _this.saxParser.ended = true;
+            return _this.emit("end", _this.resultObject);
+          }
+        };
+      })(this);
+      ontext = (function(_this) {
+        return function(text) {
+          var charChild, s;
+          s = stack[stack.length - 1];
+          if (s) {
+            s[charkey] += text;
+            if (_this.options.explicitChildren && _this.options.preserveChildrenOrder && _this.options.charsAsChildren && (_this.options.includeWhiteChars || text.replace(/\\n/g, '').trim() !== '')) {
+              s[_this.options.childkey] = s[_this.options.childkey] || [];
+              charChild = {
+                '#name': '__text__'
+              };
+              charChild[charkey] = text;
+              if (_this.options.normalize) {
+                charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, " ").trim();
+              }
+              s[_this.options.childkey].push(charChild);
+            }
+            return s;
+          }
+        };
+      })(this);
+      this.saxParser.ontext = ontext;
+      return this.saxParser.oncdata = (function(_this) {
+        return function(text) {
+          var s;
+          s = ontext(text);
+          if (s) {
+            return s.cdata = true;
+          }
+        };
+      })(this);
+    };
+
+    Parser.prototype.parseString = function(str, cb) {
+      var err;
+      if ((cb != null) && typeof cb === "function") {
+        this.on("end", function(result) {
+          this.reset();
+          return cb(null, result);
+        });
+        this.on("error", function(err) {
+          this.reset();
+          return cb(err);
+        });
+      }
+      try {
+        str = str.toString();
+        if (str.trim() === '') {
+          this.emit("end", null);
+          return true;
+        }
+        str = bom.stripBOM(str);
+        if (this.options.async) {
+          this.remaining = str;
+          setImmediate(this.processAsync);
+          return this.saxParser;
+        }
+        return this.saxParser.write(str).close();
+      } catch (error1) {
+        err = error1;
+        if (!(this.saxParser.errThrown || this.saxParser.ended)) {
+          this.emit('error', err);
+          return this.saxParser.errThrown = true;
+        } else if (this.saxParser.ended) {
+          throw err;
+        }
+      }
+    };
+
+    Parser.prototype.parseStringPromise = function(str) {
+      return new Promise((function(_this) {
+        return function(resolve, reject) {
+          return _this.parseString(str, function(err, value) {
+            if (err) {
+              return reject(err);
+            } else {
+              return resolve(value);
+            }
+          });
+        };
+      })(this));
+    };
+
+    return Parser;
+
+  })(events);
+
+  exports.parseString = function(str, a, b) {
+    var cb, options, parser;
+    if (b != null) {
+      if (typeof b === 'function') {
+        cb = b;
+      }
+      if (typeof a === 'object') {
+        options = a;
+      }
+    } else {
+      if (typeof a === 'function') {
+        cb = a;
+      }
+      options = {};
+    }
+    parser = new exports.Parser(options);
+    return parser.parseString(str, cb);
+  };
+
+  exports.parseStringPromise = function(str, a) {
+    var options, parser;
+    if (typeof a === 'object') {
+      options = a;
+    }
+    parser = new exports.Parser(options);
+    return parser.parseStringPromise(str);
+  };
+
+}).call(this);
+
+
+/***/ }),
 /* 390 */,
 /* 391 */,
 /* 392 */,
@@ -45911,7 +46605,93 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 589 */,
 /* 590 */,
 /* 591 */,
-/* 592 */,
+/* 592 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const conversions = __webpack_require__(600);
+const route = __webpack_require__(260);
+
+const convert = {};
+
+const models = Object.keys(conversions);
+
+function wrapRaw(fn) {
+	const wrappedFn = function (...args) {
+		const arg0 = args[0];
+		if (arg0 === undefined || arg0 === null) {
+			return arg0;
+		}
+
+		if (arg0.length > 1) {
+			args = arg0;
+		}
+
+		return fn(args);
+	};
+
+	// Preserve .conversion property if there is one
+	if ('conversion' in fn) {
+		wrappedFn.conversion = fn.conversion;
+	}
+
+	return wrappedFn;
+}
+
+function wrapRounded(fn) {
+	const wrappedFn = function (...args) {
+		const arg0 = args[0];
+
+		if (arg0 === undefined || arg0 === null) {
+			return arg0;
+		}
+
+		if (arg0.length > 1) {
+			args = arg0;
+		}
+
+		const result = fn(args);
+
+		// We're assuming the result is an array here.
+		// see notice in conversions.js; don't use box types
+		// in conversion functions.
+		if (typeof result === 'object') {
+			for (let len = result.length, i = 0; i < len; i++) {
+				result[i] = Math.round(result[i]);
+			}
+		}
+
+		return result;
+	};
+
+	// Preserve .conversion property if there is one
+	if ('conversion' in fn) {
+		wrappedFn.conversion = fn.conversion;
+	}
+
+	return wrappedFn;
+}
+
+models.forEach(fromModel => {
+	convert[fromModel] = {};
+
+	Object.defineProperty(convert[fromModel], 'channels', {value: conversions[fromModel].channels});
+	Object.defineProperty(convert[fromModel], 'labels', {value: conversions[fromModel].labels});
+
+	const routes = route(fromModel);
+	const routeModels = Object.keys(routes);
+
+	routeModels.forEach(toModel => {
+		const fn = routes[toModel];
+
+		convert[fromModel][toModel] = wrapRounded(fn);
+		convert[fromModel][toModel].raw = wrapRaw(fn);
+	});
+});
+
+module.exports = convert;
+
+
+/***/ }),
 /* 593 */,
 /* 594 */,
 /* 595 */,
@@ -46005,7 +46785,851 @@ exports.partialMatch = partialMatch;
 /***/ }),
 /* 598 */,
 /* 599 */,
-/* 600 */,
+/* 600 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+/* MIT license */
+/* eslint-disable no-mixed-operators */
+const cssKeywords = __webpack_require__(885);
+
+// NOTE: conversions should only return primitive values (i.e. arrays, or
+//       values that give correct `typeof` results).
+//       do not use box values types (i.e. Number(), String(), etc.)
+
+const reverseKeywords = {};
+for (const key of Object.keys(cssKeywords)) {
+	reverseKeywords[cssKeywords[key]] = key;
+}
+
+const convert = {
+	rgb: {channels: 3, labels: 'rgb'},
+	hsl: {channels: 3, labels: 'hsl'},
+	hsv: {channels: 3, labels: 'hsv'},
+	hwb: {channels: 3, labels: 'hwb'},
+	cmyk: {channels: 4, labels: 'cmyk'},
+	xyz: {channels: 3, labels: 'xyz'},
+	lab: {channels: 3, labels: 'lab'},
+	lch: {channels: 3, labels: 'lch'},
+	hex: {channels: 1, labels: ['hex']},
+	keyword: {channels: 1, labels: ['keyword']},
+	ansi16: {channels: 1, labels: ['ansi16']},
+	ansi256: {channels: 1, labels: ['ansi256']},
+	hcg: {channels: 3, labels: ['h', 'c', 'g']},
+	apple: {channels: 3, labels: ['r16', 'g16', 'b16']},
+	gray: {channels: 1, labels: ['gray']}
+};
+
+module.exports = convert;
+
+// Hide .channels and .labels properties
+for (const model of Object.keys(convert)) {
+	if (!('channels' in convert[model])) {
+		throw new Error('missing channels property: ' + model);
+	}
+
+	if (!('labels' in convert[model])) {
+		throw new Error('missing channel labels property: ' + model);
+	}
+
+	if (convert[model].labels.length !== convert[model].channels) {
+		throw new Error('channel and label counts mismatch: ' + model);
+	}
+
+	const {channels, labels} = convert[model];
+	delete convert[model].channels;
+	delete convert[model].labels;
+	Object.defineProperty(convert[model], 'channels', {value: channels});
+	Object.defineProperty(convert[model], 'labels', {value: labels});
+}
+
+convert.rgb.hsl = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const min = Math.min(r, g, b);
+	const max = Math.max(r, g, b);
+	const delta = max - min;
+	let h;
+	let s;
+
+	if (max === min) {
+		h = 0;
+	} else if (r === max) {
+		h = (g - b) / delta;
+	} else if (g === max) {
+		h = 2 + (b - r) / delta;
+	} else if (b === max) {
+		h = 4 + (r - g) / delta;
+	}
+
+	h = Math.min(h * 60, 360);
+
+	if (h < 0) {
+		h += 360;
+	}
+
+	const l = (min + max) / 2;
+
+	if (max === min) {
+		s = 0;
+	} else if (l <= 0.5) {
+		s = delta / (max + min);
+	} else {
+		s = delta / (2 - max - min);
+	}
+
+	return [h, s * 100, l * 100];
+};
+
+convert.rgb.hsv = function (rgb) {
+	let rdif;
+	let gdif;
+	let bdif;
+	let h;
+	let s;
+
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const v = Math.max(r, g, b);
+	const diff = v - Math.min(r, g, b);
+	const diffc = function (c) {
+		return (v - c) / 6 / diff + 1 / 2;
+	};
+
+	if (diff === 0) {
+		h = 0;
+		s = 0;
+	} else {
+		s = diff / v;
+		rdif = diffc(r);
+		gdif = diffc(g);
+		bdif = diffc(b);
+
+		if (r === v) {
+			h = bdif - gdif;
+		} else if (g === v) {
+			h = (1 / 3) + rdif - bdif;
+		} else if (b === v) {
+			h = (2 / 3) + gdif - rdif;
+		}
+
+		if (h < 0) {
+			h += 1;
+		} else if (h > 1) {
+			h -= 1;
+		}
+	}
+
+	return [
+		h * 360,
+		s * 100,
+		v * 100
+	];
+};
+
+convert.rgb.hwb = function (rgb) {
+	const r = rgb[0];
+	const g = rgb[1];
+	let b = rgb[2];
+	const h = convert.rgb.hsl(rgb)[0];
+	const w = 1 / 255 * Math.min(r, Math.min(g, b));
+
+	b = 1 - 1 / 255 * Math.max(r, Math.max(g, b));
+
+	return [h, w * 100, b * 100];
+};
+
+convert.rgb.cmyk = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+
+	const k = Math.min(1 - r, 1 - g, 1 - b);
+	const c = (1 - r - k) / (1 - k) || 0;
+	const m = (1 - g - k) / (1 - k) || 0;
+	const y = (1 - b - k) / (1 - k) || 0;
+
+	return [c * 100, m * 100, y * 100, k * 100];
+};
+
+function comparativeDistance(x, y) {
+	/*
+		See https://en.m.wikipedia.org/wiki/Euclidean_distance#Squared_Euclidean_distance
+	*/
+	return (
+		((x[0] - y[0]) ** 2) +
+		((x[1] - y[1]) ** 2) +
+		((x[2] - y[2]) ** 2)
+	);
+}
+
+convert.rgb.keyword = function (rgb) {
+	const reversed = reverseKeywords[rgb];
+	if (reversed) {
+		return reversed;
+	}
+
+	let currentClosestDistance = Infinity;
+	let currentClosestKeyword;
+
+	for (const keyword of Object.keys(cssKeywords)) {
+		const value = cssKeywords[keyword];
+
+		// Compute comparative distance
+		const distance = comparativeDistance(rgb, value);
+
+		// Check if its less, if so set as closest
+		if (distance < currentClosestDistance) {
+			currentClosestDistance = distance;
+			currentClosestKeyword = keyword;
+		}
+	}
+
+	return currentClosestKeyword;
+};
+
+convert.keyword.rgb = function (keyword) {
+	return cssKeywords[keyword];
+};
+
+convert.rgb.xyz = function (rgb) {
+	let r = rgb[0] / 255;
+	let g = rgb[1] / 255;
+	let b = rgb[2] / 255;
+
+	// Assume sRGB
+	r = r > 0.04045 ? (((r + 0.055) / 1.055) ** 2.4) : (r / 12.92);
+	g = g > 0.04045 ? (((g + 0.055) / 1.055) ** 2.4) : (g / 12.92);
+	b = b > 0.04045 ? (((b + 0.055) / 1.055) ** 2.4) : (b / 12.92);
+
+	const x = (r * 0.4124) + (g * 0.3576) + (b * 0.1805);
+	const y = (r * 0.2126) + (g * 0.7152) + (b * 0.0722);
+	const z = (r * 0.0193) + (g * 0.1192) + (b * 0.9505);
+
+	return [x * 100, y * 100, z * 100];
+};
+
+convert.rgb.lab = function (rgb) {
+	const xyz = convert.rgb.xyz(rgb);
+	let x = xyz[0];
+	let y = xyz[1];
+	let z = xyz[2];
+
+	x /= 95.047;
+	y /= 100;
+	z /= 108.883;
+
+	x = x > 0.008856 ? (x ** (1 / 3)) : (7.787 * x) + (16 / 116);
+	y = y > 0.008856 ? (y ** (1 / 3)) : (7.787 * y) + (16 / 116);
+	z = z > 0.008856 ? (z ** (1 / 3)) : (7.787 * z) + (16 / 116);
+
+	const l = (116 * y) - 16;
+	const a = 500 * (x - y);
+	const b = 200 * (y - z);
+
+	return [l, a, b];
+};
+
+convert.hsl.rgb = function (hsl) {
+	const h = hsl[0] / 360;
+	const s = hsl[1] / 100;
+	const l = hsl[2] / 100;
+	let t2;
+	let t3;
+	let val;
+
+	if (s === 0) {
+		val = l * 255;
+		return [val, val, val];
+	}
+
+	if (l < 0.5) {
+		t2 = l * (1 + s);
+	} else {
+		t2 = l + s - l * s;
+	}
+
+	const t1 = 2 * l - t2;
+
+	const rgb = [0, 0, 0];
+	for (let i = 0; i < 3; i++) {
+		t3 = h + 1 / 3 * -(i - 1);
+		if (t3 < 0) {
+			t3++;
+		}
+
+		if (t3 > 1) {
+			t3--;
+		}
+
+		if (6 * t3 < 1) {
+			val = t1 + (t2 - t1) * 6 * t3;
+		} else if (2 * t3 < 1) {
+			val = t2;
+		} else if (3 * t3 < 2) {
+			val = t1 + (t2 - t1) * (2 / 3 - t3) * 6;
+		} else {
+			val = t1;
+		}
+
+		rgb[i] = val * 255;
+	}
+
+	return rgb;
+};
+
+convert.hsl.hsv = function (hsl) {
+	const h = hsl[0];
+	let s = hsl[1] / 100;
+	let l = hsl[2] / 100;
+	let smin = s;
+	const lmin = Math.max(l, 0.01);
+
+	l *= 2;
+	s *= (l <= 1) ? l : 2 - l;
+	smin *= lmin <= 1 ? lmin : 2 - lmin;
+	const v = (l + s) / 2;
+	const sv = l === 0 ? (2 * smin) / (lmin + smin) : (2 * s) / (l + s);
+
+	return [h, sv * 100, v * 100];
+};
+
+convert.hsv.rgb = function (hsv) {
+	const h = hsv[0] / 60;
+	const s = hsv[1] / 100;
+	let v = hsv[2] / 100;
+	const hi = Math.floor(h) % 6;
+
+	const f = h - Math.floor(h);
+	const p = 255 * v * (1 - s);
+	const q = 255 * v * (1 - (s * f));
+	const t = 255 * v * (1 - (s * (1 - f)));
+	v *= 255;
+
+	switch (hi) {
+		case 0:
+			return [v, t, p];
+		case 1:
+			return [q, v, p];
+		case 2:
+			return [p, v, t];
+		case 3:
+			return [p, q, v];
+		case 4:
+			return [t, p, v];
+		case 5:
+			return [v, p, q];
+	}
+};
+
+convert.hsv.hsl = function (hsv) {
+	const h = hsv[0];
+	const s = hsv[1] / 100;
+	const v = hsv[2] / 100;
+	const vmin = Math.max(v, 0.01);
+	let sl;
+	let l;
+
+	l = (2 - s) * v;
+	const lmin = (2 - s) * vmin;
+	sl = s * vmin;
+	sl /= (lmin <= 1) ? lmin : 2 - lmin;
+	sl = sl || 0;
+	l /= 2;
+
+	return [h, sl * 100, l * 100];
+};
+
+// http://dev.w3.org/csswg/css-color/#hwb-to-rgb
+convert.hwb.rgb = function (hwb) {
+	const h = hwb[0] / 360;
+	let wh = hwb[1] / 100;
+	let bl = hwb[2] / 100;
+	const ratio = wh + bl;
+	let f;
+
+	// Wh + bl cant be > 1
+	if (ratio > 1) {
+		wh /= ratio;
+		bl /= ratio;
+	}
+
+	const i = Math.floor(6 * h);
+	const v = 1 - bl;
+	f = 6 * h - i;
+
+	if ((i & 0x01) !== 0) {
+		f = 1 - f;
+	}
+
+	const n = wh + f * (v - wh); // Linear interpolation
+
+	let r;
+	let g;
+	let b;
+	/* eslint-disable max-statements-per-line,no-multi-spaces */
+	switch (i) {
+		default:
+		case 6:
+		case 0: r = v;  g = n;  b = wh; break;
+		case 1: r = n;  g = v;  b = wh; break;
+		case 2: r = wh; g = v;  b = n; break;
+		case 3: r = wh; g = n;  b = v; break;
+		case 4: r = n;  g = wh; b = v; break;
+		case 5: r = v;  g = wh; b = n; break;
+	}
+	/* eslint-enable max-statements-per-line,no-multi-spaces */
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert.cmyk.rgb = function (cmyk) {
+	const c = cmyk[0] / 100;
+	const m = cmyk[1] / 100;
+	const y = cmyk[2] / 100;
+	const k = cmyk[3] / 100;
+
+	const r = 1 - Math.min(1, c * (1 - k) + k);
+	const g = 1 - Math.min(1, m * (1 - k) + k);
+	const b = 1 - Math.min(1, y * (1 - k) + k);
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert.xyz.rgb = function (xyz) {
+	const x = xyz[0] / 100;
+	const y = xyz[1] / 100;
+	const z = xyz[2] / 100;
+	let r;
+	let g;
+	let b;
+
+	r = (x * 3.2406) + (y * -1.5372) + (z * -0.4986);
+	g = (x * -0.9689) + (y * 1.8758) + (z * 0.0415);
+	b = (x * 0.0557) + (y * -0.2040) + (z * 1.0570);
+
+	// Assume sRGB
+	r = r > 0.0031308
+		? ((1.055 * (r ** (1.0 / 2.4))) - 0.055)
+		: r * 12.92;
+
+	g = g > 0.0031308
+		? ((1.055 * (g ** (1.0 / 2.4))) - 0.055)
+		: g * 12.92;
+
+	b = b > 0.0031308
+		? ((1.055 * (b ** (1.0 / 2.4))) - 0.055)
+		: b * 12.92;
+
+	r = Math.min(Math.max(0, r), 1);
+	g = Math.min(Math.max(0, g), 1);
+	b = Math.min(Math.max(0, b), 1);
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert.xyz.lab = function (xyz) {
+	let x = xyz[0];
+	let y = xyz[1];
+	let z = xyz[2];
+
+	x /= 95.047;
+	y /= 100;
+	z /= 108.883;
+
+	x = x > 0.008856 ? (x ** (1 / 3)) : (7.787 * x) + (16 / 116);
+	y = y > 0.008856 ? (y ** (1 / 3)) : (7.787 * y) + (16 / 116);
+	z = z > 0.008856 ? (z ** (1 / 3)) : (7.787 * z) + (16 / 116);
+
+	const l = (116 * y) - 16;
+	const a = 500 * (x - y);
+	const b = 200 * (y - z);
+
+	return [l, a, b];
+};
+
+convert.lab.xyz = function (lab) {
+	const l = lab[0];
+	const a = lab[1];
+	const b = lab[2];
+	let x;
+	let y;
+	let z;
+
+	y = (l + 16) / 116;
+	x = a / 500 + y;
+	z = y - b / 200;
+
+	const y2 = y ** 3;
+	const x2 = x ** 3;
+	const z2 = z ** 3;
+	y = y2 > 0.008856 ? y2 : (y - 16 / 116) / 7.787;
+	x = x2 > 0.008856 ? x2 : (x - 16 / 116) / 7.787;
+	z = z2 > 0.008856 ? z2 : (z - 16 / 116) / 7.787;
+
+	x *= 95.047;
+	y *= 100;
+	z *= 108.883;
+
+	return [x, y, z];
+};
+
+convert.lab.lch = function (lab) {
+	const l = lab[0];
+	const a = lab[1];
+	const b = lab[2];
+	let h;
+
+	const hr = Math.atan2(b, a);
+	h = hr * 360 / 2 / Math.PI;
+
+	if (h < 0) {
+		h += 360;
+	}
+
+	const c = Math.sqrt(a * a + b * b);
+
+	return [l, c, h];
+};
+
+convert.lch.lab = function (lch) {
+	const l = lch[0];
+	const c = lch[1];
+	const h = lch[2];
+
+	const hr = h / 360 * 2 * Math.PI;
+	const a = c * Math.cos(hr);
+	const b = c * Math.sin(hr);
+
+	return [l, a, b];
+};
+
+convert.rgb.ansi16 = function (args, saturation = null) {
+	const [r, g, b] = args;
+	let value = saturation === null ? convert.rgb.hsv(args)[2] : saturation; // Hsv -> ansi16 optimization
+
+	value = Math.round(value / 50);
+
+	if (value === 0) {
+		return 30;
+	}
+
+	let ansi = 30
+		+ ((Math.round(b / 255) << 2)
+		| (Math.round(g / 255) << 1)
+		| Math.round(r / 255));
+
+	if (value === 2) {
+		ansi += 60;
+	}
+
+	return ansi;
+};
+
+convert.hsv.ansi16 = function (args) {
+	// Optimization here; we already know the value and don't need to get
+	// it converted for us.
+	return convert.rgb.ansi16(convert.hsv.rgb(args), args[2]);
+};
+
+convert.rgb.ansi256 = function (args) {
+	const r = args[0];
+	const g = args[1];
+	const b = args[2];
+
+	// We use the extended greyscale palette here, with the exception of
+	// black and white. normal palette only has 4 greyscale shades.
+	if (r === g && g === b) {
+		if (r < 8) {
+			return 16;
+		}
+
+		if (r > 248) {
+			return 231;
+		}
+
+		return Math.round(((r - 8) / 247) * 24) + 232;
+	}
+
+	const ansi = 16
+		+ (36 * Math.round(r / 255 * 5))
+		+ (6 * Math.round(g / 255 * 5))
+		+ Math.round(b / 255 * 5);
+
+	return ansi;
+};
+
+convert.ansi16.rgb = function (args) {
+	let color = args % 10;
+
+	// Handle greyscale
+	if (color === 0 || color === 7) {
+		if (args > 50) {
+			color += 3.5;
+		}
+
+		color = color / 10.5 * 255;
+
+		return [color, color, color];
+	}
+
+	const mult = (~~(args > 50) + 1) * 0.5;
+	const r = ((color & 1) * mult) * 255;
+	const g = (((color >> 1) & 1) * mult) * 255;
+	const b = (((color >> 2) & 1) * mult) * 255;
+
+	return [r, g, b];
+};
+
+convert.ansi256.rgb = function (args) {
+	// Handle greyscale
+	if (args >= 232) {
+		const c = (args - 232) * 10 + 8;
+		return [c, c, c];
+	}
+
+	args -= 16;
+
+	let rem;
+	const r = Math.floor(args / 36) / 5 * 255;
+	const g = Math.floor((rem = args % 36) / 6) / 5 * 255;
+	const b = (rem % 6) / 5 * 255;
+
+	return [r, g, b];
+};
+
+convert.rgb.hex = function (args) {
+	const integer = ((Math.round(args[0]) & 0xFF) << 16)
+		+ ((Math.round(args[1]) & 0xFF) << 8)
+		+ (Math.round(args[2]) & 0xFF);
+
+	const string = integer.toString(16).toUpperCase();
+	return '000000'.substring(string.length) + string;
+};
+
+convert.hex.rgb = function (args) {
+	const match = args.toString(16).match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
+	if (!match) {
+		return [0, 0, 0];
+	}
+
+	let colorString = match[0];
+
+	if (match[0].length === 3) {
+		colorString = colorString.split('').map(char => {
+			return char + char;
+		}).join('');
+	}
+
+	const integer = parseInt(colorString, 16);
+	const r = (integer >> 16) & 0xFF;
+	const g = (integer >> 8) & 0xFF;
+	const b = integer & 0xFF;
+
+	return [r, g, b];
+};
+
+convert.rgb.hcg = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const max = Math.max(Math.max(r, g), b);
+	const min = Math.min(Math.min(r, g), b);
+	const chroma = (max - min);
+	let grayscale;
+	let hue;
+
+	if (chroma < 1) {
+		grayscale = min / (1 - chroma);
+	} else {
+		grayscale = 0;
+	}
+
+	if (chroma <= 0) {
+		hue = 0;
+	} else
+	if (max === r) {
+		hue = ((g - b) / chroma) % 6;
+	} else
+	if (max === g) {
+		hue = 2 + (b - r) / chroma;
+	} else {
+		hue = 4 + (r - g) / chroma;
+	}
+
+	hue /= 6;
+	hue %= 1;
+
+	return [hue * 360, chroma * 100, grayscale * 100];
+};
+
+convert.hsl.hcg = function (hsl) {
+	const s = hsl[1] / 100;
+	const l = hsl[2] / 100;
+
+	const c = l < 0.5 ? (2.0 * s * l) : (2.0 * s * (1.0 - l));
+
+	let f = 0;
+	if (c < 1.0) {
+		f = (l - 0.5 * c) / (1.0 - c);
+	}
+
+	return [hsl[0], c * 100, f * 100];
+};
+
+convert.hsv.hcg = function (hsv) {
+	const s = hsv[1] / 100;
+	const v = hsv[2] / 100;
+
+	const c = s * v;
+	let f = 0;
+
+	if (c < 1.0) {
+		f = (v - c) / (1 - c);
+	}
+
+	return [hsv[0], c * 100, f * 100];
+};
+
+convert.hcg.rgb = function (hcg) {
+	const h = hcg[0] / 360;
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	if (c === 0.0) {
+		return [g * 255, g * 255, g * 255];
+	}
+
+	const pure = [0, 0, 0];
+	const hi = (h % 1) * 6;
+	const v = hi % 1;
+	const w = 1 - v;
+	let mg = 0;
+
+	/* eslint-disable max-statements-per-line */
+	switch (Math.floor(hi)) {
+		case 0:
+			pure[0] = 1; pure[1] = v; pure[2] = 0; break;
+		case 1:
+			pure[0] = w; pure[1] = 1; pure[2] = 0; break;
+		case 2:
+			pure[0] = 0; pure[1] = 1; pure[2] = v; break;
+		case 3:
+			pure[0] = 0; pure[1] = w; pure[2] = 1; break;
+		case 4:
+			pure[0] = v; pure[1] = 0; pure[2] = 1; break;
+		default:
+			pure[0] = 1; pure[1] = 0; pure[2] = w;
+	}
+	/* eslint-enable max-statements-per-line */
+
+	mg = (1.0 - c) * g;
+
+	return [
+		(c * pure[0] + mg) * 255,
+		(c * pure[1] + mg) * 255,
+		(c * pure[2] + mg) * 255
+	];
+};
+
+convert.hcg.hsv = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	const v = c + g * (1.0 - c);
+	let f = 0;
+
+	if (v > 0.0) {
+		f = c / v;
+	}
+
+	return [hcg[0], f * 100, v * 100];
+};
+
+convert.hcg.hsl = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	const l = g * (1.0 - c) + 0.5 * c;
+	let s = 0;
+
+	if (l > 0.0 && l < 0.5) {
+		s = c / (2 * l);
+	} else
+	if (l >= 0.5 && l < 1.0) {
+		s = c / (2 * (1 - l));
+	}
+
+	return [hcg[0], s * 100, l * 100];
+};
+
+convert.hcg.hwb = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+	const v = c + g * (1.0 - c);
+	return [hcg[0], (v - c) * 100, (1 - v) * 100];
+};
+
+convert.hwb.hcg = function (hwb) {
+	const w = hwb[1] / 100;
+	const b = hwb[2] / 100;
+	const v = 1 - b;
+	const c = v - w;
+	let g = 0;
+
+	if (c < 1) {
+		g = (v - c) / (1 - c);
+	}
+
+	return [hwb[0], c * 100, g * 100];
+};
+
+convert.apple.rgb = function (apple) {
+	return [(apple[0] / 65535) * 255, (apple[1] / 65535) * 255, (apple[2] / 65535) * 255];
+};
+
+convert.rgb.apple = function (rgb) {
+	return [(rgb[0] / 255) * 65535, (rgb[1] / 255) * 65535, (rgb[2] / 255) * 65535];
+};
+
+convert.gray.rgb = function (args) {
+	return [args[0] / 100 * 255, args[0] / 100 * 255, args[0] / 100 * 255];
+};
+
+convert.gray.hsl = function (args) {
+	return [0, 0, args[0]];
+};
+
+convert.gray.hsv = convert.gray.hsl;
+
+convert.gray.hwb = function (gray) {
+	return [0, 100, gray[0]];
+};
+
+convert.gray.cmyk = function (gray) {
+	return [0, 0, 0, gray[0]];
+};
+
+convert.gray.lab = function (gray) {
+	return [gray[0], 0, 0];
+};
+
+convert.gray.hex = function (gray) {
+	const val = Math.round(gray[0] / 100 * 255) & 0xFF;
+	const integer = (val << 16) + (val << 8) + val;
+
+	const string = integer.toString(16).toUpperCase();
+	return '000000'.substring(string.length) + string;
+};
+
+convert.rgb.gray = function (rgb) {
+	const val = (rgb[0] + rgb[1] + rgb[2]) / 3;
+	return [val / 255 * 100];
+};
+
+
+/***/ }),
 /* 601 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -49524,7 +51148,177 @@ Object.defineProperty(exports, "__esModule", { value: true });
 
 /***/ }),
 /* 662 */,
-/* 663 */,
+/* 663 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+/* module decorator */ module = __webpack_require__.nmd(module);
+
+
+const wrapAnsi16 = (fn, offset) => (...args) => {
+	const code = fn(...args);
+	return `\u001B[${code + offset}m`;
+};
+
+const wrapAnsi256 = (fn, offset) => (...args) => {
+	const code = fn(...args);
+	return `\u001B[${38 + offset};5;${code}m`;
+};
+
+const wrapAnsi16m = (fn, offset) => (...args) => {
+	const rgb = fn(...args);
+	return `\u001B[${38 + offset};2;${rgb[0]};${rgb[1]};${rgb[2]}m`;
+};
+
+const ansi2ansi = n => n;
+const rgb2rgb = (r, g, b) => [r, g, b];
+
+const setLazyProperty = (object, property, get) => {
+	Object.defineProperty(object, property, {
+		get: () => {
+			const value = get();
+
+			Object.defineProperty(object, property, {
+				value,
+				enumerable: true,
+				configurable: true
+			});
+
+			return value;
+		},
+		enumerable: true,
+		configurable: true
+	});
+};
+
+/** @type {typeof import('color-convert')} */
+let colorConvert;
+const makeDynamicStyles = (wrap, targetSpace, identity, isBackground) => {
+	if (colorConvert === undefined) {
+		colorConvert = __webpack_require__(592);
+	}
+
+	const offset = isBackground ? 10 : 0;
+	const styles = {};
+
+	for (const [sourceSpace, suite] of Object.entries(colorConvert)) {
+		const name = sourceSpace === 'ansi16' ? 'ansi' : sourceSpace;
+		if (sourceSpace === targetSpace) {
+			styles[name] = wrap(identity, offset);
+		} else if (typeof suite === 'object') {
+			styles[name] = wrap(suite[targetSpace], offset);
+		}
+	}
+
+	return styles;
+};
+
+function assembleStyles() {
+	const codes = new Map();
+	const styles = {
+		modifier: {
+			reset: [0, 0],
+			// 21 isn't widely supported and 22 does the same thing
+			bold: [1, 22],
+			dim: [2, 22],
+			italic: [3, 23],
+			underline: [4, 24],
+			inverse: [7, 27],
+			hidden: [8, 28],
+			strikethrough: [9, 29]
+		},
+		color: {
+			black: [30, 39],
+			red: [31, 39],
+			green: [32, 39],
+			yellow: [33, 39],
+			blue: [34, 39],
+			magenta: [35, 39],
+			cyan: [36, 39],
+			white: [37, 39],
+
+			// Bright color
+			blackBright: [90, 39],
+			redBright: [91, 39],
+			greenBright: [92, 39],
+			yellowBright: [93, 39],
+			blueBright: [94, 39],
+			magentaBright: [95, 39],
+			cyanBright: [96, 39],
+			whiteBright: [97, 39]
+		},
+		bgColor: {
+			bgBlack: [40, 49],
+			bgRed: [41, 49],
+			bgGreen: [42, 49],
+			bgYellow: [43, 49],
+			bgBlue: [44, 49],
+			bgMagenta: [45, 49],
+			bgCyan: [46, 49],
+			bgWhite: [47, 49],
+
+			// Bright color
+			bgBlackBright: [100, 49],
+			bgRedBright: [101, 49],
+			bgGreenBright: [102, 49],
+			bgYellowBright: [103, 49],
+			bgBlueBright: [104, 49],
+			bgMagentaBright: [105, 49],
+			bgCyanBright: [106, 49],
+			bgWhiteBright: [107, 49]
+		}
+	};
+
+	// Alias bright black as gray (and grey)
+	styles.color.gray = styles.color.blackBright;
+	styles.bgColor.bgGray = styles.bgColor.bgBlackBright;
+	styles.color.grey = styles.color.blackBright;
+	styles.bgColor.bgGrey = styles.bgColor.bgBlackBright;
+
+	for (const [groupName, group] of Object.entries(styles)) {
+		for (const [styleName, style] of Object.entries(group)) {
+			styles[styleName] = {
+				open: `\u001B[${style[0]}m`,
+				close: `\u001B[${style[1]}m`
+			};
+
+			group[styleName] = styles[styleName];
+
+			codes.set(style[0], style[1]);
+		}
+
+		Object.defineProperty(styles, groupName, {
+			value: group,
+			enumerable: false
+		});
+	}
+
+	Object.defineProperty(styles, 'codes', {
+		value: codes,
+		enumerable: false
+	});
+
+	styles.color.close = '\u001B[39m';
+	styles.bgColor.close = '\u001B[49m';
+
+	setLazyProperty(styles.color, 'ansi', () => makeDynamicStyles(wrapAnsi16, 'ansi16', ansi2ansi, false));
+	setLazyProperty(styles.color, 'ansi256', () => makeDynamicStyles(wrapAnsi256, 'ansi256', ansi2ansi, false));
+	setLazyProperty(styles.color, 'ansi16m', () => makeDynamicStyles(wrapAnsi16m, 'rgb', rgb2rgb, false));
+	setLazyProperty(styles.bgColor, 'ansi', () => makeDynamicStyles(wrapAnsi16, 'ansi16', ansi2ansi, true));
+	setLazyProperty(styles.bgColor, 'ansi256', () => makeDynamicStyles(wrapAnsi256, 'ansi256', ansi2ansi, true));
+	setLazyProperty(styles.bgColor, 'ansi16m', () => makeDynamicStyles(wrapAnsi16m, 'rgb', rgb2rgb, true));
+
+	return styles;
+}
+
+// Make the export immutable
+Object.defineProperty(module, 'exports', {
+	enumerable: true,
+	get: assembleStyles
+});
+
+
+/***/ }),
 /* 664 */,
 /* 665 */,
 /* 666 */,
@@ -57763,389 +59557,161 @@ exports.TraceAPI = TraceAPI;
 
 /***/ }),
 /* 885 */
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(module) {
 
-// Generated by CoffeeScript 1.12.7
-(function() {
-  "use strict";
-  var bom, defaults, events, isEmpty, processItem, processors, sax, setImmediate,
-    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-    extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-    hasProp = {}.hasOwnProperty;
+"use strict";
 
-  sax = __webpack_require__(645);
 
-  events = __webpack_require__(614);
-
-  bom = __webpack_require__(210);
-
-  processors = __webpack_require__(350);
-
-  setImmediate = __webpack_require__(343).setImmediate;
-
-  defaults = __webpack_require__(791).defaults;
-
-  isEmpty = function(thing) {
-    return typeof thing === "object" && (thing != null) && Object.keys(thing).length === 0;
-  };
-
-  processItem = function(processors, item, key) {
-    var i, len, process;
-    for (i = 0, len = processors.length; i < len; i++) {
-      process = processors[i];
-      item = process(item, key);
-    }
-    return item;
-  };
-
-  exports.Parser = (function(superClass) {
-    extend(Parser, superClass);
-
-    function Parser(opts) {
-      this.parseStringPromise = bind(this.parseStringPromise, this);
-      this.parseString = bind(this.parseString, this);
-      this.reset = bind(this.reset, this);
-      this.assignOrPush = bind(this.assignOrPush, this);
-      this.processAsync = bind(this.processAsync, this);
-      var key, ref, value;
-      if (!(this instanceof exports.Parser)) {
-        return new exports.Parser(opts);
-      }
-      this.options = {};
-      ref = defaults["0.2"];
-      for (key in ref) {
-        if (!hasProp.call(ref, key)) continue;
-        value = ref[key];
-        this.options[key] = value;
-      }
-      for (key in opts) {
-        if (!hasProp.call(opts, key)) continue;
-        value = opts[key];
-        this.options[key] = value;
-      }
-      if (this.options.xmlns) {
-        this.options.xmlnskey = this.options.attrkey + "ns";
-      }
-      if (this.options.normalizeTags) {
-        if (!this.options.tagNameProcessors) {
-          this.options.tagNameProcessors = [];
-        }
-        this.options.tagNameProcessors.unshift(processors.normalize);
-      }
-      this.reset();
-    }
-
-    Parser.prototype.processAsync = function() {
-      var chunk, err;
-      try {
-        if (this.remaining.length <= this.options.chunkSize) {
-          chunk = this.remaining;
-          this.remaining = '';
-          this.saxParser = this.saxParser.write(chunk);
-          return this.saxParser.close();
-        } else {
-          chunk = this.remaining.substr(0, this.options.chunkSize);
-          this.remaining = this.remaining.substr(this.options.chunkSize, this.remaining.length);
-          this.saxParser = this.saxParser.write(chunk);
-          return setImmediate(this.processAsync);
-        }
-      } catch (error1) {
-        err = error1;
-        if (!this.saxParser.errThrown) {
-          this.saxParser.errThrown = true;
-          return this.emit(err);
-        }
-      }
-    };
-
-    Parser.prototype.assignOrPush = function(obj, key, newValue) {
-      if (!(key in obj)) {
-        if (!this.options.explicitArray) {
-          return obj[key] = newValue;
-        } else {
-          return obj[key] = [newValue];
-        }
-      } else {
-        if (!(obj[key] instanceof Array)) {
-          obj[key] = [obj[key]];
-        }
-        return obj[key].push(newValue);
-      }
-    };
-
-    Parser.prototype.reset = function() {
-      var attrkey, charkey, ontext, stack;
-      this.removeAllListeners();
-      this.saxParser = sax.parser(this.options.strict, {
-        trim: false,
-        normalize: false,
-        xmlns: this.options.xmlns
-      });
-      this.saxParser.errThrown = false;
-      this.saxParser.onerror = (function(_this) {
-        return function(error) {
-          _this.saxParser.resume();
-          if (!_this.saxParser.errThrown) {
-            _this.saxParser.errThrown = true;
-            return _this.emit("error", error);
-          }
-        };
-      })(this);
-      this.saxParser.onend = (function(_this) {
-        return function() {
-          if (!_this.saxParser.ended) {
-            _this.saxParser.ended = true;
-            return _this.emit("end", _this.resultObject);
-          }
-        };
-      })(this);
-      this.saxParser.ended = false;
-      this.EXPLICIT_CHARKEY = this.options.explicitCharkey;
-      this.resultObject = null;
-      stack = [];
-      attrkey = this.options.attrkey;
-      charkey = this.options.charkey;
-      this.saxParser.onopentag = (function(_this) {
-        return function(node) {
-          var key, newValue, obj, processedKey, ref;
-          obj = {};
-          obj[charkey] = "";
-          if (!_this.options.ignoreAttrs) {
-            ref = node.attributes;
-            for (key in ref) {
-              if (!hasProp.call(ref, key)) continue;
-              if (!(attrkey in obj) && !_this.options.mergeAttrs) {
-                obj[attrkey] = {};
-              }
-              newValue = _this.options.attrValueProcessors ? processItem(_this.options.attrValueProcessors, node.attributes[key], key) : node.attributes[key];
-              processedKey = _this.options.attrNameProcessors ? processItem(_this.options.attrNameProcessors, key) : key;
-              if (_this.options.mergeAttrs) {
-                _this.assignOrPush(obj, processedKey, newValue);
-              } else {
-                obj[attrkey][processedKey] = newValue;
-              }
-            }
-          }
-          obj["#name"] = _this.options.tagNameProcessors ? processItem(_this.options.tagNameProcessors, node.name) : node.name;
-          if (_this.options.xmlns) {
-            obj[_this.options.xmlnskey] = {
-              uri: node.uri,
-              local: node.local
-            };
-          }
-          return stack.push(obj);
-        };
-      })(this);
-      this.saxParser.onclosetag = (function(_this) {
-        return function() {
-          var cdata, emptyStr, key, node, nodeName, obj, objClone, old, s, xpath;
-          obj = stack.pop();
-          nodeName = obj["#name"];
-          if (!_this.options.explicitChildren || !_this.options.preserveChildrenOrder) {
-            delete obj["#name"];
-          }
-          if (obj.cdata === true) {
-            cdata = obj.cdata;
-            delete obj.cdata;
-          }
-          s = stack[stack.length - 1];
-          if (obj[charkey].match(/^\s*$/) && !cdata) {
-            emptyStr = obj[charkey];
-            delete obj[charkey];
-          } else {
-            if (_this.options.trim) {
-              obj[charkey] = obj[charkey].trim();
-            }
-            if (_this.options.normalize) {
-              obj[charkey] = obj[charkey].replace(/\s{2,}/g, " ").trim();
-            }
-            obj[charkey] = _this.options.valueProcessors ? processItem(_this.options.valueProcessors, obj[charkey], nodeName) : obj[charkey];
-            if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
-              obj = obj[charkey];
-            }
-          }
-          if (isEmpty(obj)) {
-            obj = _this.options.emptyTag !== '' ? _this.options.emptyTag : emptyStr;
-          }
-          if (_this.options.validator != null) {
-            xpath = "/" + ((function() {
-              var i, len, results;
-              results = [];
-              for (i = 0, len = stack.length; i < len; i++) {
-                node = stack[i];
-                results.push(node["#name"]);
-              }
-              return results;
-            })()).concat(nodeName).join("/");
-            (function() {
-              var err;
-              try {
-                return obj = _this.options.validator(xpath, s && s[nodeName], obj);
-              } catch (error1) {
-                err = error1;
-                return _this.emit("error", err);
-              }
-            })();
-          }
-          if (_this.options.explicitChildren && !_this.options.mergeAttrs && typeof obj === 'object') {
-            if (!_this.options.preserveChildrenOrder) {
-              node = {};
-              if (_this.options.attrkey in obj) {
-                node[_this.options.attrkey] = obj[_this.options.attrkey];
-                delete obj[_this.options.attrkey];
-              }
-              if (!_this.options.charsAsChildren && _this.options.charkey in obj) {
-                node[_this.options.charkey] = obj[_this.options.charkey];
-                delete obj[_this.options.charkey];
-              }
-              if (Object.getOwnPropertyNames(obj).length > 0) {
-                node[_this.options.childkey] = obj;
-              }
-              obj = node;
-            } else if (s) {
-              s[_this.options.childkey] = s[_this.options.childkey] || [];
-              objClone = {};
-              for (key in obj) {
-                if (!hasProp.call(obj, key)) continue;
-                objClone[key] = obj[key];
-              }
-              s[_this.options.childkey].push(objClone);
-              delete obj["#name"];
-              if (Object.keys(obj).length === 1 && charkey in obj && !_this.EXPLICIT_CHARKEY) {
-                obj = obj[charkey];
-              }
-            }
-          }
-          if (stack.length > 0) {
-            return _this.assignOrPush(s, nodeName, obj);
-          } else {
-            if (_this.options.explicitRoot) {
-              old = obj;
-              obj = {};
-              obj[nodeName] = old;
-            }
-            _this.resultObject = obj;
-            _this.saxParser.ended = true;
-            return _this.emit("end", _this.resultObject);
-          }
-        };
-      })(this);
-      ontext = (function(_this) {
-        return function(text) {
-          var charChild, s;
-          s = stack[stack.length - 1];
-          if (s) {
-            s[charkey] += text;
-            if (_this.options.explicitChildren && _this.options.preserveChildrenOrder && _this.options.charsAsChildren && (_this.options.includeWhiteChars || text.replace(/\\n/g, '').trim() !== '')) {
-              s[_this.options.childkey] = s[_this.options.childkey] || [];
-              charChild = {
-                '#name': '__text__'
-              };
-              charChild[charkey] = text;
-              if (_this.options.normalize) {
-                charChild[charkey] = charChild[charkey].replace(/\s{2,}/g, " ").trim();
-              }
-              s[_this.options.childkey].push(charChild);
-            }
-            return s;
-          }
-        };
-      })(this);
-      this.saxParser.ontext = ontext;
-      return this.saxParser.oncdata = (function(_this) {
-        return function(text) {
-          var s;
-          s = ontext(text);
-          if (s) {
-            return s.cdata = true;
-          }
-        };
-      })(this);
-    };
-
-    Parser.prototype.parseString = function(str, cb) {
-      var err;
-      if ((cb != null) && typeof cb === "function") {
-        this.on("end", function(result) {
-          this.reset();
-          return cb(null, result);
-        });
-        this.on("error", function(err) {
-          this.reset();
-          return cb(err);
-        });
-      }
-      try {
-        str = str.toString();
-        if (str.trim() === '') {
-          this.emit("end", null);
-          return true;
-        }
-        str = bom.stripBOM(str);
-        if (this.options.async) {
-          this.remaining = str;
-          setImmediate(this.processAsync);
-          return this.saxParser;
-        }
-        return this.saxParser.write(str).close();
-      } catch (error1) {
-        err = error1;
-        if (!(this.saxParser.errThrown || this.saxParser.ended)) {
-          this.emit('error', err);
-          return this.saxParser.errThrown = true;
-        } else if (this.saxParser.ended) {
-          throw err;
-        }
-      }
-    };
-
-    Parser.prototype.parseStringPromise = function(str) {
-      return new Promise((function(_this) {
-        return function(resolve, reject) {
-          return _this.parseString(str, function(err, value) {
-            if (err) {
-              return reject(err);
-            } else {
-              return resolve(value);
-            }
-          });
-        };
-      })(this));
-    };
-
-    return Parser;
-
-  })(events);
-
-  exports.parseString = function(str, a, b) {
-    var cb, options, parser;
-    if (b != null) {
-      if (typeof b === 'function') {
-        cb = b;
-      }
-      if (typeof a === 'object') {
-        options = a;
-      }
-    } else {
-      if (typeof a === 'function') {
-        cb = a;
-      }
-      options = {};
-    }
-    parser = new exports.Parser(options);
-    return parser.parseString(str, cb);
-  };
-
-  exports.parseStringPromise = function(str, a) {
-    var options, parser;
-    if (typeof a === 'object') {
-      options = a;
-    }
-    parser = new exports.Parser(options);
-    return parser.parseStringPromise(str);
-  };
-
-}).call(this);
+module.exports = {
+	"aliceblue": [240, 248, 255],
+	"antiquewhite": [250, 235, 215],
+	"aqua": [0, 255, 255],
+	"aquamarine": [127, 255, 212],
+	"azure": [240, 255, 255],
+	"beige": [245, 245, 220],
+	"bisque": [255, 228, 196],
+	"black": [0, 0, 0],
+	"blanchedalmond": [255, 235, 205],
+	"blue": [0, 0, 255],
+	"blueviolet": [138, 43, 226],
+	"brown": [165, 42, 42],
+	"burlywood": [222, 184, 135],
+	"cadetblue": [95, 158, 160],
+	"chartreuse": [127, 255, 0],
+	"chocolate": [210, 105, 30],
+	"coral": [255, 127, 80],
+	"cornflowerblue": [100, 149, 237],
+	"cornsilk": [255, 248, 220],
+	"crimson": [220, 20, 60],
+	"cyan": [0, 255, 255],
+	"darkblue": [0, 0, 139],
+	"darkcyan": [0, 139, 139],
+	"darkgoldenrod": [184, 134, 11],
+	"darkgray": [169, 169, 169],
+	"darkgreen": [0, 100, 0],
+	"darkgrey": [169, 169, 169],
+	"darkkhaki": [189, 183, 107],
+	"darkmagenta": [139, 0, 139],
+	"darkolivegreen": [85, 107, 47],
+	"darkorange": [255, 140, 0],
+	"darkorchid": [153, 50, 204],
+	"darkred": [139, 0, 0],
+	"darksalmon": [233, 150, 122],
+	"darkseagreen": [143, 188, 143],
+	"darkslateblue": [72, 61, 139],
+	"darkslategray": [47, 79, 79],
+	"darkslategrey": [47, 79, 79],
+	"darkturquoise": [0, 206, 209],
+	"darkviolet": [148, 0, 211],
+	"deeppink": [255, 20, 147],
+	"deepskyblue": [0, 191, 255],
+	"dimgray": [105, 105, 105],
+	"dimgrey": [105, 105, 105],
+	"dodgerblue": [30, 144, 255],
+	"firebrick": [178, 34, 34],
+	"floralwhite": [255, 250, 240],
+	"forestgreen": [34, 139, 34],
+	"fuchsia": [255, 0, 255],
+	"gainsboro": [220, 220, 220],
+	"ghostwhite": [248, 248, 255],
+	"gold": [255, 215, 0],
+	"goldenrod": [218, 165, 32],
+	"gray": [128, 128, 128],
+	"green": [0, 128, 0],
+	"greenyellow": [173, 255, 47],
+	"grey": [128, 128, 128],
+	"honeydew": [240, 255, 240],
+	"hotpink": [255, 105, 180],
+	"indianred": [205, 92, 92],
+	"indigo": [75, 0, 130],
+	"ivory": [255, 255, 240],
+	"khaki": [240, 230, 140],
+	"lavender": [230, 230, 250],
+	"lavenderblush": [255, 240, 245],
+	"lawngreen": [124, 252, 0],
+	"lemonchiffon": [255, 250, 205],
+	"lightblue": [173, 216, 230],
+	"lightcoral": [240, 128, 128],
+	"lightcyan": [224, 255, 255],
+	"lightgoldenrodyellow": [250, 250, 210],
+	"lightgray": [211, 211, 211],
+	"lightgreen": [144, 238, 144],
+	"lightgrey": [211, 211, 211],
+	"lightpink": [255, 182, 193],
+	"lightsalmon": [255, 160, 122],
+	"lightseagreen": [32, 178, 170],
+	"lightskyblue": [135, 206, 250],
+	"lightslategray": [119, 136, 153],
+	"lightslategrey": [119, 136, 153],
+	"lightsteelblue": [176, 196, 222],
+	"lightyellow": [255, 255, 224],
+	"lime": [0, 255, 0],
+	"limegreen": [50, 205, 50],
+	"linen": [250, 240, 230],
+	"magenta": [255, 0, 255],
+	"maroon": [128, 0, 0],
+	"mediumaquamarine": [102, 205, 170],
+	"mediumblue": [0, 0, 205],
+	"mediumorchid": [186, 85, 211],
+	"mediumpurple": [147, 112, 219],
+	"mediumseagreen": [60, 179, 113],
+	"mediumslateblue": [123, 104, 238],
+	"mediumspringgreen": [0, 250, 154],
+	"mediumturquoise": [72, 209, 204],
+	"mediumvioletred": [199, 21, 133],
+	"midnightblue": [25, 25, 112],
+	"mintcream": [245, 255, 250],
+	"mistyrose": [255, 228, 225],
+	"moccasin": [255, 228, 181],
+	"navajowhite": [255, 222, 173],
+	"navy": [0, 0, 128],
+	"oldlace": [253, 245, 230],
+	"olive": [128, 128, 0],
+	"olivedrab": [107, 142, 35],
+	"orange": [255, 165, 0],
+	"orangered": [255, 69, 0],
+	"orchid": [218, 112, 214],
+	"palegoldenrod": [238, 232, 170],
+	"palegreen": [152, 251, 152],
+	"paleturquoise": [175, 238, 238],
+	"palevioletred": [219, 112, 147],
+	"papayawhip": [255, 239, 213],
+	"peachpuff": [255, 218, 185],
+	"peru": [205, 133, 63],
+	"pink": [255, 192, 203],
+	"plum": [221, 160, 221],
+	"powderblue": [176, 224, 230],
+	"purple": [128, 0, 128],
+	"rebeccapurple": [102, 51, 153],
+	"red": [255, 0, 0],
+	"rosybrown": [188, 143, 143],
+	"royalblue": [65, 105, 225],
+	"saddlebrown": [139, 69, 19],
+	"salmon": [250, 128, 114],
+	"sandybrown": [244, 164, 96],
+	"seagreen": [46, 139, 87],
+	"seashell": [255, 245, 238],
+	"sienna": [160, 82, 45],
+	"silver": [192, 192, 192],
+	"skyblue": [135, 206, 235],
+	"slateblue": [106, 90, 205],
+	"slategray": [112, 128, 144],
+	"slategrey": [112, 128, 144],
+	"snow": [255, 250, 250],
+	"springgreen": [0, 255, 127],
+	"steelblue": [70, 130, 180],
+	"tan": [210, 180, 140],
+	"teal": [0, 128, 128],
+	"thistle": [216, 191, 216],
+	"tomato": [255, 99, 71],
+	"turquoise": [64, 224, 208],
+	"violet": [238, 130, 238],
+	"wheat": [245, 222, 179],
+	"white": [255, 255, 255],
+	"whitesmoke": [245, 245, 245],
+	"yellow": [255, 255, 0],
+	"yellowgreen": [154, 205, 50]
+};
 
 
 /***/ }),
@@ -60786,7 +62352,7 @@ exports.exec = exec;
 
   builder = __webpack_require__(476);
 
-  parser = __webpack_require__(885);
+  parser = __webpack_require__(389);
 
   processors = __webpack_require__(350);
 
@@ -66150,4 +67716,26 @@ exports.userAgentPolicy = userAgentPolicy;
 
 
 /***/ })
-/******/ ]);
+/******/ ],
+/******/ function(__webpack_require__) { // webpackRuntimeModules
+/******/ 	"use strict";
+/******/ 
+/******/ 	/* webpack/runtime/node module decorator */
+/******/ 	!function() {
+/******/ 		__webpack_require__.nmd = function(module) {
+/******/ 			module.paths = [];
+/******/ 			if (!module.children) module.children = [];
+/******/ 			Object.defineProperty(module, 'loaded', {
+/******/ 				enumerable: true,
+/******/ 				get: function() { return module.l; }
+/******/ 			});
+/******/ 			Object.defineProperty(module, 'id', {
+/******/ 				enumerable: true,
+/******/ 				get: function() { return module.i; }
+/******/ 			});
+/******/ 			return module;
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ }
+);

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -6780,8 +6780,8 @@ function fetchCheckSuiteId(runId) {
                 if (!currentRun) {
                     throw `Unexpected error: No run returned`;
                 }
-                if (currentRun.status !== `in_progress`) {
-                    throw `Unexpected error: Expected status of 'in_progress', got '${currentRun.status}': ` + util_1.inspect(currentRun);
+                if (currentRun.conclusion) {
+                    throw `Unexpected error: Expected Check Suite with no conclusion, got: ` + util_1.inspect(currentRun);
                 }
                 // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`
                 currentCheckSuiteId = (_a = parseInt(currentRun.check_suite_url.substr(1 + currentRun.check_suite_url.lastIndexOf(`/`)))) !== null && _a !== void 0 ? _a : -1;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
   "scripts": {
     "prepare-setup-go": "cd node_modules/setup-go && npm run build",
     "prepare-deps": "npm run prepare-setup-go",
-    "build": "tsc && ncc build -o dist/run/ src/main.ts && ncc build -o dist/post_run/ src/post_main.ts",
+    "build": "tsc && npm run build_pre && npm run build_main && npm run build_post_main",
+    "build_pre": "ncc build -o dist/pre/ src/setup.ts",
+    "build_main": "ncc build -o dist/run/ src/main.ts",
+    "build_post_main": "ncc build -o dist/post_run/ src/post_main.ts",
+    "watched_build_pre": "tsc && ncc build -w -o dist/pre/ src/setup.ts",
     "watched_build_main": "tsc && ncc build -w -o dist/run/ src/main.ts",
     "watched_build_post_main": "tsc && ncc build -w -o dist/post_run/ src/post_main.ts",
     "type-check": "tsc",
@@ -15,7 +19,8 @@
     "lint-fix": "eslint **/*.ts --cache --fix",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
-    "all": "npm run prepare-deps && npm run build && npm run format-check && npm run lint",
+    "all": "npm run prepare-deps && npm run format-check && npm run build && npm run lint",
+    "all-format": "npm run format && npm run all",
     "local": "npm run build && act -j test -b",
     "local-full-version": "npm run build && act -j test-full-version -b"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,4 +15,10 @@ export enum Events {
   PullRequest = "pull_request",
 }
 
+export enum Env {
+  LintPath = "GOLANGCI_LINT_ACTION_LINT_PATH",
+  PatchPath = "GOLANGCI_LINT_ACTION_PATCH_PATH",
+  CheckRunIdent = "GOLANGCI_LINT_ACTION_CHECK_RUN_IDENT",
+}
+
 export const RefKey = "GITHUB_REF"

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core"
 import * as github from "@actions/github"
+import style from "ansi-styles"
 import { exec, ExecOptions } from "child_process"
 import * as fs from "fs"
 import * as path from "path"
@@ -100,6 +101,253 @@ async function prepareEnv(): Promise<Env> {
 type ExecRes = {
   stdout: string
   stderr: string
+  code?: number
+}
+
+enum LintSeverity {
+  notice,
+  warning,
+  failure,
+}
+
+type LintSeverityStrings = keyof typeof LintSeverity
+
+type LintIssue = {
+  Text: string
+  FromLinter: string
+  Severity: LintSeverityStrings
+  SourceLines: string[]
+  Pos: {
+    Filename: string
+    Line: number
+    Column: number
+  }
+  LineRange?: {
+    From: number
+    To: number
+  }
+  Replacement: {
+    NeedOnlyDelete: boolean
+    NewLines: string[] | null
+    Inline: {
+      StartCol: number
+      Length: number
+      NewString: string
+    } | null
+  } | null
+}
+
+type UnfilteredLintIssue =
+  | LintIssue
+  | {
+      Severity: string
+    }
+
+type LintOutput = {
+  Issues: LintIssue[]
+  Report: {
+    Warnings?: {
+      Tag?: string
+      Text: string
+    }[]
+    Linters?: {
+      Enabled: boolean
+      Name: string
+    }[]
+    Error?: string
+  }
+}
+
+type GithubAnnotation = {
+  path: string
+  start_line: number
+  end_line: number
+  start_column?: number
+  end_column?: number
+  title: string
+  message: string
+  annotation_level: LintSeverityStrings
+  raw_details?: string
+}
+
+type CheckRun = {
+  id: number
+  output: {
+    title: string
+  }
+}
+
+type SeverityMap = {
+  [key: string]: LintSeverityStrings
+}
+
+const DefaultFailureSeverity = LintSeverity.notice
+
+const parseOutput = (json: string): LintOutput => {
+  const severityMap: SeverityMap = {
+    info: `notice`,
+    notice: `notice`,
+    minor: `warning`,
+    warning: `warning`,
+    error: `failure`,
+    major: `failure`,
+    critical: `failure`,
+    blocker: `failure`,
+    failure: `failure`,
+  }
+  const lintOutput = JSON.parse(json)
+  if (!lintOutput.Report) {
+    throw `golangci-lint returned invalid json`
+  }
+  if (lintOutput.Issues.length) {
+    lintOutput.Issues = lintOutput.Issues.filter((issue: UnfilteredLintIssue) => issue.Severity !== `ignore`).map(
+      (issue: UnfilteredLintIssue): LintIssue => {
+        const Severity = issue.Severity.toLowerCase()
+        issue.Severity = severityMap[`${Severity}`] ? severityMap[`${Severity}`] : `failure`
+        return issue as LintIssue
+      }
+    )
+  }
+  return lintOutput as LintOutput
+}
+
+const logLintIssues = (issues: LintIssue[]): void => {
+  issues.forEach((issue: LintIssue): void => {
+    let header = `${style.red.open}${style.bold.open}Lint Error:${style.bold.close}${style.red.close}`
+    if (issue.Severity === `warning`) {
+      header = `${style.yellow.open}${style.bold.open}Lint Warning:${style.bold.close}${style.yellow.close}`
+    } else if (issue.Severity === `notice`) {
+      header = `${style.cyan.open}${style.bold.open}Lint Notice:${style.bold.close}${style.cyan.close}`
+    }
+
+    let pos = `${issue.Pos.Filename}:${issue.Pos.Line}`
+    if (issue.LineRange !== undefined) {
+      pos += `-${issue.LineRange.To}`
+    } else if (issue.Pos.Column) {
+      pos += `:${issue.Pos.Column}`
+    }
+
+    core.info(`${header} ${pos} - ${issue.Text} (${issue.FromLinter})`)
+  })
+}
+
+async function annotateLintIssues(issues: LintIssue[]): Promise<void> {
+  if (!issues.length) {
+    return
+  }
+  const ctx = github.context
+  const ref = ctx.payload.after
+  const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }))
+  const checkRunsPromise = octokit.checks
+    .listForRef({
+      ...ctx.repo,
+      ref,
+      status: "in_progress",
+    })
+    .catch((e) => {
+      throw `Error getting Check Run Data: ${e}`
+    })
+
+  const chunkSize = 50
+  const issueCounts = {
+    notice: 0,
+    warning: 0,
+    failure: 0,
+  }
+  const githubAnnotations: GithubAnnotation[] = issues.map(
+    (issue: LintIssue): GithubAnnotation => {
+      // If/when we transition to comments, we would build the request structure here
+      const annotation: GithubAnnotation = {
+        path: issue.Pos.Filename,
+        start_line: issue.Pos.Line,
+        end_line: issue.Pos.Line,
+        title: issue.FromLinter,
+        message: issue.Text,
+        annotation_level: issue.Severity,
+      }
+
+      issueCounts[issue.Severity]++
+
+      if (issue.LineRange !== undefined) {
+        annotation.end_line = issue.LineRange.To
+      } else if (issue.Pos.Column) {
+        annotation.start_column = issue.Pos.Column
+        annotation.end_column = issue.Pos.Column
+      }
+
+      if (issue.Replacement !== null) {
+        let replacement = ``
+        if (issue.Replacement.Inline) {
+          replacement =
+            issue.SourceLines[0].slice(0, issue.Replacement.Inline.StartCol) +
+            issue.Replacement.Inline.NewString +
+            issue.SourceLines[0].slice(issue.Replacement.Inline.StartCol + issue.Replacement.Inline.Length)
+        } else if (issue.Replacement.NewLines) {
+          replacement = issue.Replacement.NewLines.join("\n")
+        }
+        annotation.raw_details = "```suggestion\n" + replacement + "\n```"
+      }
+
+      return annotation as GithubAnnotation
+    }
+  )
+  let checkRun: CheckRun | undefined
+  const { data: checkRunsResponse } = await checkRunsPromise
+  if (checkRunsResponse.check_runs.length === 0) {
+    throw `octokit.checks.listForRef(${ref}) returned no results`
+  } else {
+    checkRun = checkRunsResponse.check_runs.find((run) => run.name.includes(`Lint`))
+  }
+  if (!checkRun?.id) {
+    throw `Could not find current check run`
+  }
+  const title = checkRun.output.title ?? `GolangCI-Lint`
+  const summary = `There are {issueCounts.failure} failures, {issueCounts.wairning} warnings, and {issueCounts.notice} notices.`
+  Array.from({ length: Math.ceil(githubAnnotations.length / chunkSize) }, (v, i) =>
+    githubAnnotations.slice(i * chunkSize, i * chunkSize + chunkSize)
+  ).forEach((annotations: GithubAnnotation[]): void => {
+    octokit.checks
+      .update({
+        ...ctx.repo,
+        check_run_id: checkRun?.id as number,
+        output: {
+          title,
+          summary,
+          annotations,
+        },
+      })
+      .catch((e) => {
+        throw `Error patching Check Run Data (annotations): ${e}`
+      })
+  })
+}
+
+const hasFailingIssues = (issues: LintIssue[]): boolean => {
+  // If the user input is not a valid Severity Level, this will be -1, and any issue will fail
+  const userFailureSeverity = core.getInput(`failure-severity`).toLowerCase()
+  let failureSeverity = DefaultFailureSeverity
+  if (userFailureSeverity) {
+    failureSeverity = Object.values(LintSeverity).indexOf(userFailureSeverity)
+  }
+  if (failureSeverity < 0) {
+    core.info(
+      `::warning::failure-severity must be one of (${Object.keys(LintSeverity).join(
+        " | "
+      )}). "${userFailureSeverity}" not supported, using default (${LintSeverity[DefaultFailureSeverity]})`
+    )
+    failureSeverity = DefaultFailureSeverity
+  }
+  if (issues.length) {
+    if (failureSeverity <= 0) {
+      return true
+    }
+    for (const issue of issues) {
+      if (failureSeverity <= LintSeverity[issue.Severity]) {
+        return true
+      }
+    }
+  }
+  return false
 }
 
 const printOutput = (res: ExecRes): void => {
@@ -109,6 +357,58 @@ const printOutput = (res: ExecRes): void => {
   if (res.stderr) {
     core.info(res.stderr)
   }
+}
+
+async function printLintOutput(res: ExecRes): Promise<void> {
+  let lintOutput: LintOutput | undefined
+  const exit_code = res.code ?? 0
+  try {
+    try {
+      if (res.stdout) {
+        // This object contains other information, such as errors and the active linters
+        // TODO: Should we do something with that data?
+        lintOutput = parseOutput(res.stdout)
+
+        if (lintOutput.Issues.length) {
+          logLintIssues(lintOutput.Issues)
+
+          // We can only Annotate (or Comment) on Push or Pull Request
+          switch (github.context.eventName) {
+            case `pull_request`:
+            // TODO: When we are ready to handle these as Comments, instead of Annotations, we would place that logic here
+            /* falls through */
+            case `push`:
+              await annotateLintIssues(lintOutput.Issues)
+              break
+            default:
+              // At this time, other events are not supported
+              break
+          }
+        }
+      }
+    } catch (e) {
+      throw `there was an error processing golangci-lint output: ${e}`
+    }
+
+    if (res.stderr) {
+      core.info(res.stderr)
+    }
+
+    if (exit_code === 1) {
+      if (lintOutput) {
+        if (hasFailingIssues(lintOutput.Issues)) {
+          throw `issues found`
+        }
+      } else {
+        throw `unexpected state, golangci-lint exited with 1, but provided no lint output`
+      }
+    } else if (exit_code > 1) {
+      throw `golangci-lint exit with code ${exit_code}`
+    }
+  } catch (e) {
+    return <void>core.setFailed(`${e}`)
+  }
+  return <void>core.info(`golangci-lint found no blocking issues`)
 }
 
 async function runLint(lintPath: string, patchPath: string): Promise<void> {
@@ -133,7 +433,7 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   if (userArgNames.has(`out-format`)) {
     throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`)
   }
-  addedArgs.push(`--out-format=github-actions`)
+  addedArgs.push(`--out-format=json`)
 
   if (patchPath) {
     if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
@@ -167,18 +467,11 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   const startedAt = Date.now()
   try {
     const res = await execShellCommand(cmd, cmdArgs)
-    printOutput(res)
-    core.info(`golangci-lint found no issues`)
+    await printLintOutput(res)
   } catch (exc) {
     // This logging passes issues to GitHub annotations but comments can be more convenient for some users.
     // TODO: support reviewdog or leaving comments by GitHub API.
-    printOutput(exc)
-
-    if (exc.code === 1) {
-      core.setFailed(`issues found`)
-    } else {
-      core.setFailed(`golangci-lint exit with code ${exc.code}`)
-    }
+    await printLintOutput(exc)
   }
 
   core.info(`Ran golangci-lint in ${Date.now() - startedAt}ms`)

--- a/src/run.ts
+++ b/src/run.ts
@@ -266,6 +266,10 @@ async function resolveCheckRunId(): Promise<number> {
         if (workflowResponse.jobs.length > 1) {
           const searchToken = uuidv4()
           core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`)
+          await ((ms): Promise<void> => {
+            core.info(`resolveCheckRunId() Sleeping for ${ms / 1000} Seconds`)
+            return new Promise((resolve) => setTimeout(resolve, ms))
+          })(2 * 1000)
           for (const job of workflowResponse.jobs) {
             try {
               const { data: annotations } = await octokit.checks.listAnnotations({

--- a/src/run.ts
+++ b/src/run.ts
@@ -247,30 +247,33 @@ async function resolveCheckRunId(): Promise<number> {
     try {
       core.info(`Attempting to resolve current GitHub Job (${ctx.runId})`)
       const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }))
-      const { data: workflowResponse } = await octokit.actions
-        .listJobsForWorkflowRun({
-          ...ctx.repo,
-          run_id: ctx.runId,
-          status: "in_progress",
-        })
-        .catch((e: string) => {
-          throw `Unable to fetch Workflow Job List: ${e}`
-        })
+      let workflowJobs = (
+        await octokit.actions
+          .listJobsForWorkflowRun({
+            ...ctx.repo,
+            run_id: ctx.runId,
+          })
+          .catch((e: string) => {
+            throw `Unable to fetch Workflow Job List: ${e}`
+          })
+      ).data.jobs.filter((job) => job.status === `in_progress`)
 
-      if (workflowResponse.jobs.length > 0) {
-        core.info(`resolveCheckRunId() Found ${workflowResponse.jobs.length} Jobs:\n` + inspect(workflowResponse.jobs))
-        if (workflowResponse.jobs.length > 1) {
-          const searchRegExp = new RegExp(`/^` + ctx.job.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + `(\\s+\\(|$)/`)
-          const jobs = workflowResponse.jobs.filter((run) => searchRegExp.test(run.name))
+      if (workflowJobs.length > 0) {
+        core.info(`resolveCheckRunId() Found ${workflowJobs.length} Jobs:\n` + inspect(workflowJobs))
+        if (workflowJobs.length > 1) {
+          const searchRegExp = new RegExp(`^` + ctx.job.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + `(\\s+\\(|$)`)
+          const jobs = workflowJobs.filter((job) => searchRegExp.test(job.name))
           core.info(`resolveCheckRunId() Found ${jobs.length} Jobs whose base name is '${ctx.job}'`)
-          workflowResponse.jobs = jobs.length ? jobs : workflowResponse.jobs
+          workflowJobs = jobs.length ? jobs : workflowJobs
         }
-        if (workflowResponse.jobs.length > 1) {
+        if (workflowJobs.length > 1) {
           const searchToken = uuidv4()
           core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`)
+          const startedAt = Date.now()
           // Sleep for MS, to allow Annotation to be captured and populated
-          await ((ms): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)))(5 * 1000)
-          for (const job of workflowResponse.jobs) {
+          await ((ms): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)))(10 * 1000)
+          core.info(`Slept for ${Date.now() - startedAt}ms`)
+          for (const job of workflowJobs) {
             try {
               const { data: annotations } = await octokit.checks.listAnnotations({
                 ...ctx.repo,
@@ -294,8 +297,8 @@ async function resolveCheckRunId(): Promise<number> {
             }
           }
           core.info(`resolveCheckRunId() Finished looking for Search Token`)
-        } else if (workflowResponse.jobs[0]) {
-          jobId = workflowResponse.jobs[0].id
+        } else if (workflowJobs[0]) {
+          jobId = workflowJobs[0].id
         } else {
           throw `Unable to resolve GitHub Job`
         }

--- a/src/run.ts
+++ b/src/run.ts
@@ -260,9 +260,7 @@ async function resolveCheckRunId(): Promise<number> {
 
   if (process.env.GITHUB_ACTIONS === `true`) {
     try {
-      const searchToken = uuidv4()
-      core.info(`::warning::Resolving GitHub CheckRunID (${searchToken})`)
-
+      core.info(`Attempting to resolve GitHub Check Run`)
       const ctx = github.context
       const ref = ctx.payload.after ?? ctx.sha
 
@@ -284,9 +282,8 @@ async function resolveCheckRunId(): Promise<number> {
           checkRuns = checkRuns.filter((run) => run.name.includes(ctx.job)) ?? checkRuns
         }
         if (checkRuns.length > 1) {
-          checkRuns = checkRuns.filter((run) => run.output.annotations_count > 0) ?? checkRuns
-        }
-        if (checkRuns.length > 1) {
+          const searchToken = uuidv4()
+          core.info(`::warning::[ignore] Resolving GitHub Check Run with Search Token: ${searchToken}`)
           for (const run of checkRuns) {
             try {
               if (
@@ -306,7 +303,7 @@ async function resolveCheckRunId(): Promise<number> {
           }
         } else if (checkRuns[0]) {
           checkRunId = checkRuns[0].id
-          core.info(`Current Check Run is: ${checkRunId}`)
+          core.info(`Current Check Run: ${checkRunId}`)
         } else {
           throw `Unable to resolve GitHub Check Run`
         }

--- a/src/run.ts
+++ b/src/run.ts
@@ -245,7 +245,8 @@ async function resolveCheckRunId(): Promise<number> {
 
   if (process.env.GITHUB_ACTIONS === `true` && ctx.runId) {
     try {
-      core.info(`Attempting to resolve current GitHub Job (${ctx.runId})`)
+      const searchToken = uuidv4()
+      core.info(`::warning::Attempting to resolve current GitHub Job ${ctx.runId}<${searchToken}>`)
       const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }))
       let workflowJobs = (
         await octokit.actions
@@ -267,12 +268,10 @@ async function resolveCheckRunId(): Promise<number> {
           workflowJobs = jobs.length ? jobs : workflowJobs
         }
         if (workflowJobs.length > 1) {
-          const searchToken = uuidv4()
-          core.info(`::warning::[ignore] Resolving GitHub Job with Search Token: ${searchToken}`)
           const startedAt = Date.now()
           // Sleep for MS, to allow Annotation to be captured and populated
           await ((ms): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)))(10 * 1000)
-          core.info(`Slept for ${Date.now() - startedAt}ms`)
+          core.info(`Paused for ${Date.now() - startedAt}ms`)
           for (const job of workflowJobs) {
             try {
               const { data: annotations } = await octokit.checks.listAnnotations({

--- a/src/run.ts
+++ b/src/run.ts
@@ -121,8 +121,8 @@ async function fetchCheckSuiteId(runId: number): Promise<number> {
         throw `Unexpected error: No run returned`
       }
 
-      if (currentRun.status !== `in_progress`) {
-        throw `Unexpected error: Expected status of 'in_progress', got '${currentRun.status}': ` + inspect(currentRun)
+      if (currentRun.conclusion) {
+        throw `Unexpected error: Expected Check Suite with no conclusion, got: ` + inspect(currentRun)
       }
 
       // The GitHub API it's self does present the `check_suite_id` property, but it is not documented or present returned object's `type`

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,3 @@
+import { setup } from "./run"
+
+setup()


### PR DESCRIPTION
Re-Issue of #207 after fixing CheckRun resolution.  All of the same comments apply:

This does a bunch...  But also, not that much.  In summary, it switches to using the `json` output of `golangci-lint` and handling the formatting and reporting to GitHub inside of the action.  This allows for a more flexibility in how the lint issues are handled than simply passing the text output to the Action Log (which is all `golangci-lint` would be able to do).  With this approach, the action can resolve a number of issues, and is in a better position to resolve a few more.  The active changes in this PR are:

- Allows verbose reporting of Issues in Run Terminal/Log, regardless of event type
  Resolves: #119
- Additionally adds support for Severity Failure levels via `--failure-level` (defaults to 'notice' [all])
  Replaces: #198

  Resolves Discussion: https://github.com/golangci/golangci-lint/discussions/1853
- Adds suggested fixes to Annotation Raw Details
  Partially Resolves: #35 
- Prepares foundation for supporting Comments
  Related: #5
- Adds mapping for common Issue Severities to GitHub Severities (Code climate | Checkstyle | GitHub)
  *This avoids a potential issue of having a severity that is not supported by GitHub configured, which, in it's current implementation, `golangci-lint` would just echo, and would not behave as expected in the Action.*
- Adds handling of 'Ignore' Issue Severity (removes from Issue List)
- Adds support for Multi-Line Annotations
- Adds support for Character Range Annotations

*Note on Severity Levels and `ignore`*: Failure is determined by `golangci-lint` exiting with a non-zero code **and** the Issues List containing *at least one* Issue with a Severity Level equal to or greater than the setting of `--failure-level`.  This defaults to `notice`, and can be one of `notice`, `warning`, or `failure`.

Ignore is stripped from the Issues list, and therefore is neither reported to the Log, or grounds for `failure` (a run that reports only Issues of severity level `ignore` will not fail, even if `golangci-lint` exits with `1`).  It is not possible to set the `failure-level` to `ignore` either.  Additionally, it is not possible to **not** fail on a severity level of `failure`.

With that in mind, this offers a few options on Conditional Failure:
- Set the Severity of a linter to `ignore`, and you will not see it or fail on it.
- Set the Severity of a linter to `notice` or `warning`, and set `--failure-level` to the next severity up.

**Consideration:** I set the default `--failure-level` to `notice` because, in the current implementation, any Lint Issue can cause a Failure, and I didn't want to change the behavior too much (that being said, handling of `ignore` already changes this behavior, but that seemed expected).  However, it would make the most sense, semantically, to have the default `--failure-level` set to `warning`.  What are your thoughts?

As you can see, if the Action has access to the full output, there is a lot that can be done fairly quickly.

With regards to Comments (#5): There is a bit of work that would need to be done to fully do this, but this sets the stage fairly nicely.