### PR TITLE
Add description for permissions settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
           - "v1.37"
           - "v1.37.1"
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v2
       - uses: ./
@@ -44,6 +47,8 @@ jobs:
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ on:
       - master
       - main
   pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
 jobs:
   golangci:
     name: lint
@@ -75,6 +79,10 @@ on:
       - master
       - main
   pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
 jobs:
   golangci:
     strategy:


### PR DESCRIPTION
This pull request is to clarify the permissions required for golangci-lint-actions.
This allows repository owners to follow the principle of least privilege in their workflows.

See also:
https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions

Note:
If update pull request comment (#5), need to grant write access to pull-requests.
