### PR TITLE
Update version to 3.1.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "golanci-lint-action",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "golangci-lint github action",
   "main": "dist/main.js",


### PR DESCRIPTION
it is not needed, since the package is private and we do not publish it to any registries, but let's be consistent