### PR TITLE
modify examples using setup-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
+        with:
+          go-version: 1.15
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -91,12 +93,14 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go: [1.15]
         os: [macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.15
+          go-version: 1.17
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -93,7 +93,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [1.15]
+        go: [1.17]
         os: [macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
README for v3 is currently almost the same as v2 (#450), which may confuse some developers.
- #442
- #448

This PR updates examples of using setup-go@v3 to configure a golang environment that works properly.
https://github.com/actions/setup-go#supported-version-syntax