### PR TITLE
Expire cache periodically to avoid unbounded size

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -66447,11 +66447,9 @@ const getIntervalKey = (invalidationIntervalDays) => {
 function buildCacheKeys() {
     return __awaiter(this, void 0, void 0, function* () {
         const keys = [];
-        let cacheKey = `golangci-lint.cache-`;
-        keys.push(cacheKey);
         // Periodically invalidate a cache because a new code being added.
         // TODO: configure it via inputs.
-        cacheKey += `${getIntervalKey(7)}-`;
+        let cacheKey = `golangci-lint.cache-${getIntervalKey(7)}-`;
         keys.push(cacheKey);
         if (yield pathExists(`go.mod`)) {
             // Add checksum to key to invalidate a cache when dependencies change.

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -66447,11 +66447,9 @@ const getIntervalKey = (invalidationIntervalDays) => {
 function buildCacheKeys() {
     return __awaiter(this, void 0, void 0, function* () {
         const keys = [];
-        let cacheKey = `golangci-lint.cache-`;
-        keys.push(cacheKey);
         // Periodically invalidate a cache because a new code being added.
         // TODO: configure it via inputs.
-        cacheKey += `${getIntervalKey(7)}-`;
+        let cacheKey = `golangci-lint.cache-${getIntervalKey(7)}-`;
         keys.push(cacheKey);
         if (yield pathExists(`go.mod`)) {
             // Add checksum to key to invalidate a cache when dependencies change.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -52,12 +52,9 @@ const getIntervalKey = (invalidationIntervalDays: number): string => {
 
 async function buildCacheKeys(): Promise<string[]> {
   const keys = []
-  let cacheKey = `golangci-lint.cache-`
-  keys.push(cacheKey)
-
   // Periodically invalidate a cache because a new code being added.
   // TODO: configure it via inputs.
-  cacheKey += `${getIntervalKey(7)}-`
+  let cacheKey = `golangci-lint.cache-${getIntervalKey(7)}-`
   keys.push(cacheKey)
 
   if (await pathExists(`go.mod`)) {


### PR DESCRIPTION
The cache key includes a sequence number that rotates every 7 days but because we are also using the base `golangci-lint.cache` as a restore key, the new cache will always be seeded with the full contents of the old cache.

In particular for the go module cache, this leads to an ever increasing number of cached packages that never get pruned.

This commit updates it so we stop using `golangci-lint.cache` as a restore key, which will force a build from an empty cache once every 7 days.

Fixes #465 