### PR TITLE
Add support to configure additional output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ typings/
 
 # Text editor files
 .vscode/
+
+# IntelliJ/WebStorm files
+.idea

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ jobs:
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 
+          # Optional: render results of golangci-lint additionally into a file; syntax: <format>:<file_path> (see also https://golangci-lint.run/usage/configuration/#output-configuration)
+          # output-file: checkstyle:golangci_lint.xml
+
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
           # skip-cache: true
@@ -115,6 +118,9 @@ jobs:
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
+
+          # Optional: render results of golangci-lint additionally into a file; syntax: <format>:<file_path> (see also https://golangci-lint.run/usage/configuration/#output-configuration)
+          # output-file: checkstyle:golangci_lint.xml
 ```
 
 You will also likely need to add the following `.gitattributes` file to ensure that line endings for windows builds are properly formatted:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: "if set to true and the action runs on a pull request - the action outputs only newly found issues"
     default: false
     required: true
+  output-file:
+    description: "render results of golangci-lint additionally into a file; syntax: <format>:<file_path> (see also https://golangci-lint.run/usage/configuration/#output-configuration)"
+    required: false
   skip-cache:
     description: |
       if set to true then the all caching functionality will be complete disabled,

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -68277,7 +68277,8 @@ function runLint(lintPath, patchPath) {
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }
-        addedArgs.push(`--out-format=github-actions`);
+        const outputFile = core.getInput(`output-file`, { required: false }).trim();
+        addedArgs.push(`--out-format=github-actions${outputFile ? "," + outputFile : ""}`);
         if (patchPath) {
             if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
                 throw new Error(`please, don't specify manually --new* args when requesting only new issues`);

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -68277,7 +68277,8 @@ function runLint(lintPath, patchPath) {
         if (userArgNames.has(`out-format`)) {
             throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
         }
-        addedArgs.push(`--out-format=github-actions`);
+        const outputFile = core.getInput(`output-file`, { required: false }).trim();
+        addedArgs.push(`--out-format=github-actions${outputFile ? "," + outputFile : ""}`);
         if (patchPath) {
             if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
                 throw new Error(`please, don't specify manually --new* args when requesting only new issues`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -130,7 +130,9 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   if (userArgNames.has(`out-format`)) {
     throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`)
   }
-  addedArgs.push(`--out-format=github-actions`)
+
+  const outputFile = core.getInput(`output-file`, { required: false }).trim()
+  addedArgs.push(`--out-format=github-actions${outputFile ? ',' + outputFile : ''}`)
 
   if (patchPath) {
     if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -132,7 +132,7 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   }
 
   const outputFile = core.getInput(`output-file`, { required: false }).trim()
-  addedArgs.push(`--out-format=github-actions${outputFile ? ',' + outputFile : ''}`)
+  addedArgs.push(`--out-format=github-actions${outputFile ? "," + outputFile : ""}`)
 
   if (patchPath) {
     if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {


### PR DESCRIPTION
As outlined in #458 the current implementation of the github action does not support additional output formats. This is especially useful to support integration with code quality tools such as SonarCloud. This PR suggests a solution strategy how this could be achieved with an additional configuration parameter.