### PR TITLE
feat: add support for pull_request_target and only-new-issues

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -89177,7 +89177,7 @@ async function fetchPatch() {
         return ``;
     }
     const ctx = github.context;
-    if (ctx.eventName !== `pull_request`) {
+    if (ctx.eventName !== `pull_request` && ctx.eventName !== `pull_request_target`) {
         core.info(`Not fetching patch for showing only new issues because it's not a pull request context: event name is ${ctx.eventName}`);
         return ``;
     }

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -89177,7 +89177,7 @@ async function fetchPatch() {
         return ``;
     }
     const ctx = github.context;
-    if (ctx.eventName !== `pull_request`) {
+    if (ctx.eventName !== `pull_request` && ctx.eventName !== `pull_request_target`) {
         core.info(`Not fetching patch for showing only new issues because it's not a pull request context: event name is ${ctx.eventName}`);
         return ``;
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -32,7 +32,7 @@ async function fetchPatch(): Promise<string> {
   }
 
   const ctx = github.context
-  if (ctx.eventName !== `pull_request`) {
+  if (ctx.eventName !== `pull_request` && ctx.eventName !== `pull_request_target`) {
     core.info(`Not fetching patch for showing only new issues because it's not a pull request context: event name is ${ctx.eventName}`)
     return ``
   }


### PR DESCRIPTION
The golangci-lint-action doesn't work when `only-new-issues: true` is specified, but the pull request was created from a private fork repository to a private repository.

See more why you would need pull_request_target for that: https://github.community/t/will-github-actions-support-pull-request-events-from-a-fork-to-a-private-base-repository/17471

The PR fixes this.

The action works perfectly with pull_request_target, but users should not forget to specify ref when running `actions/checkout`.

```
on: pull_request_target

[...]
      - uses: actions/checkout@v3
        with:
          [.. other with params ..]
          ref: "refs/pull/${{ github.event.number }}/head"
       [...]

      - name: golangci-lint
        uses: golangci/golangci-lint-action@NEW_VERSION
        with:
          only-new-issues: true
[...]
```