### PR TITLE
Increase default timeout

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -109,6 +109,8 @@ const printOutput = (res: ExecRes): void => {
   }
 }
 
+const defaultTimeout = `5m`
+
 async function runLint(lintPath: string, patchPath: string): Promise<void> {
   const debug = core.getInput(`debug`)
   if (debug.split(`,`).includes(`cache`)) {
@@ -131,6 +133,9 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
     throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`)
   }
   addedArgs.push(`--out-format=github-actions`)
+  if (!userArgNames.has(`timeout`)) {
+    addedArgs.push(`--timeout=${defaultTimeout}`)
+  }
 
   if (patchPath) {
     if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {


### PR DESCRIPTION
### motivation

I wrote why I request this change: https://github.com/golangci/golangci-lint-action/issues/297#issuecomment-1280457284

### implementation

I wrote in above comment:

> ``const cmd = `${lintPath} run --timeout 3m ...` ``

But I noticed that `Set#has` is more better way to check `--timeout` option is passed by `args:` option in   `.github/workflows/*.yml`, and noticed that `--timeout=3m` may be lacking of execution time.