### PR TITLE
fix: only-new-issues should return empty string for fetchPatch

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -67778,7 +67778,7 @@ function fetchPatch() {
         if (onlyNewIssues !== `false` && onlyNewIssues !== `true`) {
             throw new Error(`invalid value of "only-new-issues": "${onlyNewIssues}", expected "true" or "false"`);
         }
-        if (onlyNewIssues === `false`) {
+        if (onlyNewIssues === `true`) {
             return ``;
         }
         const ctx = github.context;

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -67778,7 +67778,7 @@ function fetchPatch() {
         if (onlyNewIssues !== `false` && onlyNewIssues !== `true`) {
             throw new Error(`invalid value of "only-new-issues": "${onlyNewIssues}", expected "true" or "false"`);
         }
-        if (onlyNewIssues === `false`) {
+        if (onlyNewIssues === `true`) {
             return ``;
         }
         const ctx = github.context;

--- a/src/run.ts
+++ b/src/run.ts
@@ -24,7 +24,7 @@ async function fetchPatch(): Promise<string> {
   if (onlyNewIssues !== `false` && onlyNewIssues !== `true`) {
     throw new Error(`invalid value of "only-new-issues": "${onlyNewIssues}", expected "true" or "false"`)
   }
-  if (onlyNewIssues === `false`) {
+  if (onlyNewIssues === `true`) {
     return ``
   }
 


### PR DESCRIPTION
`fetchPatch` determines the `patchPath`. If the `patchPath` is not empty, the action explicitly overrides user input and sets `--new-from-patch=<patch_path>`, `--new=false` and `--new-from-rev` to be empty. `only-new-issues` should obviously set `--new` to be `true`.

Closes #531 

Signed-off-by: Conor Evans <coevans@tcd.ie>

----

This is in `fetchPatch`. This is then used in `prepareEnv`

```typescript
async function prepareEnv(): Promise<Env> {
  // ...
  const patchPromise = fetchPatch()
  // ...
  const patchPath = await patchPromise
  // ....
  return { lintPath, patchPath }
}
```

`prepareEnv` is then used to get the arguments for `runLint` - again we have `patchPath` that should be returned as `""` when `only-new-issues` is true.

```typescript
export async function run(): Promise<void> {
// ...
    const { lintPath, patchPath } = await core.group(`prepare environment`, prepareEnv)
// ...
    await core.group(`run golangci-lint`, () => runLint(lintPath, patchPath))
```

In `runLint` the `patchPath` if set explicitly overrides the new arguments...

```typescript
async function runLint(lintPath: string, patchPath: string): Promise<void> {
  // ...

  if (patchPath) {
    if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
      throw new Error(`please, don't specify manually --new* args when requesting only new issues`)
    }
    addedArgs.push(`--new-from-patch=${patchPath}`)

    // Override config values.
    addedArgs.push(`--new=false`)
    addedArgs.push(`--new-from-rev=`)
  }
```

Pretty self explanatory fix all the same.