### PR TITLE
Optionally support multiple --out-format args in addition to default github-actions format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "if set to true then the action doesn't cache or restore ~/.cache/go-build."
     default: false
     required: false
+  allow-extra-out-format-args:
+    description: "if set to true then the action allows additional --out-format args (default of --out-format=github-actions remains)"
+    default: false
+    required: false
 runs:
   using: "node16"
   main: "dist/run/index.js"

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -67716,6 +67716,7 @@ function runLint(lintPath, patchPath) {
             printOutput(res);
         }
         const userArgs = core.getInput(`args`);
+        const allowExtraOutFormatArgs = core.getInput(`allow-extra-out-format-args`);
         const addedArgs = [];
         const userArgNames = new Set(userArgs
             .trim()
@@ -67723,8 +67724,9 @@ function runLint(lintPath, patchPath) {
             .map((arg) => arg.split(`=`)[0])
             .filter((arg) => arg.startsWith(`-`))
             .map((arg) => arg.replace(/^-+/, ``)));
-        if (userArgNames.has(`out-format`)) {
-            throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
+        if (userArgNames.has(`out-format`) && !allowExtraOutFormatArgs) {
+            throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a
+      future version (set 'allow-extra-out-format-args' input to true to override)`);
         }
         addedArgs.push(`--out-format=github-actions`);
         if (patchPath) {

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -67716,6 +67716,7 @@ function runLint(lintPath, patchPath) {
             printOutput(res);
         }
         const userArgs = core.getInput(`args`);
+        const allowExtraOutFormatArgs = core.getInput(`allow-extra-out-format-args`);
         const addedArgs = [];
         const userArgNames = new Set(userArgs
             .trim()
@@ -67723,8 +67724,9 @@ function runLint(lintPath, patchPath) {
             .map((arg) => arg.split(`=`)[0])
             .filter((arg) => arg.startsWith(`-`))
             .map((arg) => arg.replace(/^-+/, ``)));
-        if (userArgNames.has(`out-format`)) {
-            throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`);
+        if (userArgNames.has(`out-format`) && !allowExtraOutFormatArgs) {
+            throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a
+      future version (set 'allow-extra-out-format-args' input to true to override)`);
         }
         addedArgs.push(`--out-format=github-actions`);
         if (patchPath) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -117,6 +117,7 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   }
 
   const userArgs = core.getInput(`args`)
+  const allowExtraOutFormatArgs = core.getInput(`allow-extra-out-format-args`)
   const addedArgs: string[] = []
 
   const userArgNames = new Set<string>(
@@ -127,8 +128,9 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
       .filter((arg) => arg.startsWith(`-`))
       .map((arg) => arg.replace(/^-+/, ``))
   )
-  if (userArgNames.has(`out-format`)) {
-    throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`)
+  if (userArgNames.has(`out-format`) && !allowExtraOutFormatArgs) {
+    throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a
+      future version (set 'allow-extra-out-format-args' input to true to override)`)
   }
   addedArgs.push(`--out-format=github-actions`)
 


### PR DESCRIPTION
Fixes #612 