### PR TITLE
Support Caching in Mono Repo 

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -67348,9 +67348,14 @@ function buildCacheKeys() {
         // TODO: configure it via inputs.
         let cacheKey = `golangci-lint.cache-${getIntervalKey(7)}-`;
         keys.push(cacheKey);
-        if (yield pathExists(`go.mod`)) {
+        // Get working directory from input
+        const workingDirectory = core.getInput(`working-directory`);
+        // create path to go.mod prepending the workingDirectory if it exists
+        const goModPath = path_1.default.join(workingDirectory, `go.mod`);
+        core.info(`Checking for go.mod: ${goModPath}`);
+        if (yield pathExists(goModPath)) {
             // Add checksum to key to invalidate a cache when dependencies change.
-            cacheKey += yield checksumFile(`sha1`, `go.mod`);
+            cacheKey += yield checksumFile(`sha1`, goModPath);
         }
         else {
             cacheKey += `nogomod`;

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -67348,9 +67348,14 @@ function buildCacheKeys() {
         // TODO: configure it via inputs.
         let cacheKey = `golangci-lint.cache-${getIntervalKey(7)}-`;
         keys.push(cacheKey);
-        if (yield pathExists(`go.mod`)) {
+        // Get working directory from input
+        const workingDirectory = core.getInput(`working-directory`);
+        // create path to go.mod prepending the workingDirectory if it exists
+        const goModPath = path_1.default.join(workingDirectory, `go.mod`);
+        core.info(`Checking for go.mod: ${goModPath}`);
+        if (yield pathExists(goModPath)) {
             // Add checksum to key to invalidate a cache when dependencies change.
-            cacheKey += yield checksumFile(`sha1`, `go.mod`);
+            cacheKey += yield checksumFile(`sha1`, goModPath);
         }
         else {
             cacheKey += `nogomod`;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -56,10 +56,14 @@ async function buildCacheKeys(): Promise<string[]> {
   // TODO: configure it via inputs.
   let cacheKey = `golangci-lint.cache-${getIntervalKey(7)}-`
   keys.push(cacheKey)
-
-  if (await pathExists(`go.mod`)) {
+  // Get working directory from input
+  const workingDirectory = core.getInput(`working-directory`)
+  // create path to go.mod prepending the workingDirectory if it exists
+  const goModPath = path.join(workingDirectory, `go.mod`)
+  core.info(`Checking for go.mod: ${goModPath}`)
+  if (await pathExists(goModPath)) {
     // Add checksum to key to invalidate a cache when dependencies change.
-    cacheKey += await checksumFile(`sha1`, `go.mod`)
+    cacheKey += await checksumFile(`sha1`, goModPath)
   } else {
     cacheKey += `nogomod`
   }


### PR DESCRIPTION
Right now the `go.mod` is used as the cache key is expected to always be at the root of the repository. This works for most repositories but when users have a mono repo and supply a `working-directory` the caching keys should use that as the root directory instead

This PR fixes #479 


Also wanted to add that we use golangci extensively in in [CloudQuery](https://github.com/cloudquery/cloudquery) and this would definitely help us avoid hitting timeouts...