### PR TITLE
doc: add quote aroung go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: '1.17'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
I recently came across a bug (https://github.com/golangci/golangci-lint-action/issues/669) where specifying `go-version: '1.20'` used Go 1.2, not 1.20. It was not clear from the readme that to avoid this, the Go version should be written inside single quotes (as per this comment: https://github.com/actions/setup-go/issues/326#issuecomment-1415719692) but the single quotes are missing from the example in this repository.  This PR fixes this.