### PR TITLE
fix invalid docs about cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Inside our action we perform 3 steps:
 ### Caching internals
 
 1. We save and restore the following directories: `~/.cache/golangci-lint`, `~/.cache/go-build`, `~/go/pkg`.
-2. The primary caching key looks like `golangci-lint.cache-{platform-arch}-{interval_number}-{go.mod_hash}`. Interval number ensures that we periodically invalidate
+2. The primary caching key looks like `golangci-lint.cache-{interval_number}-{go.mod_hash}`. Interval number ensures that we periodically invalidate
    our cache (every 7 days). `go.mod` hash ensures that we invalidate the cache early - as soon as dependencies have changed.
-3. We use [restore keys](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key): `golangci-lint.cache-{interval_number}-`, `golangci-lint.cache-`. GitHub matches keys by prefix if we have no exact match for the primary cache.
+3. We use [restore keys](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key): `golangci-lint.cache-{interval_number}-`. GitHub matches keys by prefix if we have no exact match for the primary cache.
 
 This scheme is basic and needs improvements. Pull requests and ideas are welcome.
 


### PR DESCRIPTION
fix followings

* `platform-arch` is not used for key
    * https://github.com/golangci/golangci-lint-action/blob/92ba55cf0d79a9feb999e9bcef95c952bbbe545a/src/cache.ts#L57
* `golangci-lint.cache-` is not used as restore key
    * (if use `golangci-lint.cache-`, cache will not purged by `internal_number`)