### PR TITLE
use working-directory as cache key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,10 @@ Inside our action we perform 3 steps:
 ### Caching internals
 
 1. We save and restore the following directories: `~/.cache/golangci-lint`, `~/.cache/go-build`, `~/go/pkg`.
-2. The primary caching key looks like `golangci-lint.cache-{platform-arch}-{interval_number}-{go.mod_hash}`. Interval number ensures that we periodically invalidate
-   our cache (every 7 days). `go.mod` hash ensures that we invalidate the cache early - as soon as dependencies have changed.
-3. We use [restore keys](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key): `golangci-lint.cache-{interval_number}-`, `golangci-lint.cache-`. GitHub matches keys by prefix if we have no exact match for the primary cache.
+2. The primary caching key looks like `golangci-lint.cache-{interval_number}-{go.mod_hash}` (with `working-directory`, key will be `golangci-lint.cache-${working-directory}-{interval_number}-{go.mod_hash}`).
+   Interval number ensures that we periodically invalidate our cache (every 7 days). `go.mod` hash ensures that we invalidate the cache early - as soon as dependencies have changed.
+3. We use [restore keys](https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key): `golangci-lint.cache-{interval_number}-` (with `working-directory`, `golangci-lint.cache-${working-directory}-{interval_number}-`).
+   GitHub matches keys by prefix if we have no exact match for the primary cache.
 
 This scheme is basic and needs improvements. Pull requests and ideas are welcome.
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -54,10 +54,16 @@ async function buildCacheKeys(): Promise<string[]> {
   const keys = []
   // Periodically invalidate a cache because a new code being added.
   // TODO: configure it via inputs.
-  let cacheKey = `golangci-lint.cache-${getIntervalKey(7)}-`
-  keys.push(cacheKey)
+  let cacheKey = `golangci-lint.cache-`
   // Get working directory from input
   const workingDirectory = core.getInput(`working-directory`)
+  if (workingDirectory) {
+    cacheKey += `${workingDirectory}-`
+  }
+  cacheKey += `${getIntervalKey(7)}-`
+
+  keys.push(cacheKey)
+
   // create path to go.mod prepending the workingDirectory if it exists
   const goModPath = path.join(workingDirectory, `go.mod`)
   core.info(`Checking for go.mod: ${goModPath}`)


### PR DESCRIPTION
Currently cache conflicts in monorepo.

Use `working-directory` as cache key prefix to separate cache per working direcitories.