### PR TITLE
docs/build: update to setup-go@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,9 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
+        with:
+          cache: false # setup-go v4 caches by default
       - uses: ./
         with:
           version: ${{ matrix.version }}
@@ -80,7 +82,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
+        with:
+          cache: false # setup-go v4 caches by default
       - uses: ./
         with:
           working-directory: sample-go-mod

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.17'
+          cache: false
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -98,10 +99,11 @@ jobs:
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v3
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
setup-go v4 uses cache automatically, which conflicts with golangci-lint's cache.

This is not a fix, rather a documentation and build setup update, in 2 separated commits so they might be cherry-picked :)

refs #677