### PR TITLE
docs: fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: '1.17'
           cache: false
-      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
## Background

If `actions/setup-go@` is before `actions/checkout@v3` and go-version-file is specified in `actions/setup-go`, the go.mod file is not found because checkout is not done yet like this.

<img width="722" alt="ScreenShot 387" src="https://github.com/golangci/golangci-lint-action/assets/47182350/ae1fb1e8-1d5d-4d7c-9513-f7360d3c433f">

So it would be easier to understand if `actions/checkout@v3` is before `actions/setup-go@`.