### PR TITLE
feat: add install-mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,35 @@ jobs:
           args: --timeout=3m --issues-exit-code=0 ./sample/...
           only-new-issues: true
 
+  test-go-install: # make sure the action works on a clean machine without building (go-install mode)
+    needs: [ build ]
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        version:
+          - ""
+          - "latest"
+          - "v1.53.2"
+          - "b5093688c0d3008eaacd6066773a1a52e689252f"
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          cache: false # setup-go v4 caches by default
+      - uses: ./
+        with:
+          version: ${{ matrix.version }}
+          args: --timeout=3m --issues-exit-code=0 ./sample/...
+          only-new-issues: true
+          install-mode: goinstall
+
   test-go-mod-version:
     needs: [ build ]
     strategy:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ jobs:
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
+          
+          # Optional:The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"
 ```
 
 We recommend running this action in a job separate from other jobs (`go test`, etc)
@@ -126,6 +129,9 @@ jobs:
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
+
+          # Optional:The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"
 ```
 
 You will also likely need to add the following `.gitattributes` file to ensure that line endings for windows builds are properly formatted:

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "if set to true then the action doesn't cache or restore ~/.cache/go-build."
     default: false
     required: false
+  install-mode:
+    description: "The mode to install golangci-lint. It can be 'binary' or 'goinstall'."
+    default: "binary"
+    required: false
 runs:
   using: "node16"
   main: "dist/run/index.js"

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,9 +1,13 @@
 import * as core from "@actions/core"
 import * as tc from "@actions/tool-cache"
+import { exec, ExecOptions } from "child_process"
 import os from "os"
 import path from "path"
+import { promisify } from "util"
 
 import { VersionConfig } from "./version"
+
+const execShellCommand = promisify(exec)
 
 const downloadURL = "https://github.com/golangci/golangci-lint/releases/download"
 
@@ -31,13 +35,95 @@ const getAssetURL = (versionConfig: VersionConfig): string => {
   return `${downloadURL}/${versionConfig.TargetVersion}/golangci-lint-${noPrefix}-${platform}-${arch}.${ext}`
 }
 
-// The installLint returns path to installed binary of golangci-lint.
-export async function installLint(versionConfig: VersionConfig): Promise<string> {
+export enum InstallMode {
+  Binary = "binary",
+  GoInstall = "goinstall",
+}
+
+type ExecRes = {
+  stdout: string
+  stderr: string
+}
+
+const printOutput = (res: ExecRes): void => {
+  if (res.stdout) {
+    core.info(res.stdout)
+  }
+  if (res.stderr) {
+    core.info(res.stderr)
+  }
+}
+
+/**
+ * Install golangci-lint.
+ *
+ * @param versionConfig information about version to install.
+ * @param mode          installation mode.
+ * @returns             path to installed binary of golangci-lint.
+ */
+export async function installLint(versionConfig: VersionConfig, mode: InstallMode): Promise<string> {
+  core.info(`Installation mode: ${mode}`)
+
+  switch (mode) {
+    case InstallMode.Binary:
+      return installBin(versionConfig)
+    case InstallMode.GoInstall:
+      return goInstall(versionConfig)
+    default:
+      return installBin(versionConfig)
+  }
+}
+
+/**
+ * Install golangci-lint via `go install`.
+ *
+ * @param versionConfig information about version to install.
+ * @returns             path to installed binary of golangci-lint.
+ */
+export async function goInstall(versionConfig: VersionConfig): Promise<string> {
   core.info(`Installing golangci-lint ${versionConfig.TargetVersion}...`)
+
   const startedAt = Date.now()
+
+  const options: ExecOptions = { env: { ...process.env, CGO_ENABLED: "1" } }
+
+  const exres = await execShellCommand(
+    `go install github.com/golangci/golangci-lint/cmd/golangci-lint@${versionConfig.TargetVersion}`,
+    options
+  )
+  printOutput(exres)
+
+  const res = await execShellCommand(
+    `go install -n github.com/golangci/golangci-lint/cmd/golangci-lint@${versionConfig.TargetVersion}`,
+    options
+  )
+  printOutput(res)
+
+  // The output of `go install -n` when the binary is already installed is `touch <path_to_the_binary>`.
+  const lintPath = res.stderr.trimStart().trimEnd().split(` `, 2)[1]
+
+  core.info(`Installed golangci-lint into ${lintPath} in ${Date.now() - startedAt}ms`)
+
+  return lintPath
+}
+
+/**
+ * Install golangci-lint via the precompiled binary.
+ *
+ * @param versionConfig information about version to install.
+ * @returns             path to installed binary of golangci-lint.
+ */
+export async function installBin(versionConfig: VersionConfig): Promise<string> {
+  core.info(`Installing golangci-lint binary ${versionConfig.TargetVersion}...`)
+
+  const startedAt = Date.now()
+
   const assetURL = getAssetURL(versionConfig)
-  core.info(`Downloading ${assetURL} ...`)
+
+  core.info(`Downloading binary ${assetURL} ...`)
+
   const archivePath = await tc.downloadTool(assetURL)
+
   let extractedDir = ""
   let repl = /\.tar\.gz$/
   if (assetURL.endsWith("zip")) {
@@ -55,6 +141,8 @@ export async function installLint(versionConfig: VersionConfig): Promise<string>
   const urlParts = assetURL.split(`/`)
   const dirName = urlParts[urlParts.length - 1].replace(repl, ``)
   const lintPath = path.join(extractedDir, dirName, `golangci-lint`)
+
   core.info(`Installed golangci-lint into ${lintPath} in ${Date.now() - startedAt}ms`)
+
   return lintPath
 }


### PR DESCRIPTION
Allow installing golangci-lint by using `go install`.

Fixes #540
Fixes #201
Closes #676

Related to #690