### PR TITLE
feat: support out-format as args

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -66581,12 +66581,12 @@ function runLint(lintPath, patchPath) {
             .filter((arg) => arg.startsWith(`-`))
             .map((arg) => arg.replace(/^-+/, ``))
             .map((arg) => arg.split(/=(.*)/, 2))
-            .map(([key, value]) => [key, value !== null && value !== void 0 ? value : '']);
+            .map(([key, value]) => [key, value !== null && value !== void 0 ? value : ""]);
         const userArgsMap = new Map(userArgsList);
         const userArgNames = new Set(userArgsList.map(([key, value]) => key));
-        const formats = userArgsMap.get('out-format');
+        const formats = userArgsMap.get("out-format");
         if (formats) {
-            if (formats.includes('github-actions')) {
+            if (formats.includes("github-actions")) {
                 addedArgs.push(`--out-format=${formats}`);
             }
             else {

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -66581,21 +66581,17 @@ function runLint(lintPath, patchPath) {
             .filter((arg) => arg.startsWith(`-`))
             .map((arg) => arg.replace(/^-+/, ``))
             .map((arg) => arg.split(/=(.*)/, 2))
-            .map(([key, value]) => [key, value !== null && value !== void 0 ? value : ""]);
+            .map(([key, value]) => [key.toLowerCase(), value !== null && value !== void 0 ? value : ""]);
         const userArgsMap = new Map(userArgsList);
-        const userArgNames = new Set(userArgsList.map(([key, value]) => key));
-        const formats = userArgsMap.get("out-format");
-        if (formats) {
-            if (formats.includes("github-actions")) {
-                addedArgs.push(`--out-format=${formats}`);
-            }
-            else {
-                addedArgs.push(`--out-format=github-actions,${formats}`);
-            }
-        }
-        else {
-            addedArgs.push(`--out-format=github-actions`);
-        }
+        const userArgNames = new Set(userArgsList.map(([key]) => key));
+        const formats = (userArgsMap.get("out-format") || "")
+            .trim()
+            .split(",")
+            .filter((f) => f.length > 0)
+            .filter((f) => !f.startsWith(`github-actions`))
+            .concat("github-actions")
+            .join(",");
+        addedArgs.push(`--out-format=${formats}`);
         if (patchPath) {
             if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
                 throw new Error(`please, don't specify manually --new* args when requesting only new issues`);

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -66581,12 +66581,12 @@ function runLint(lintPath, patchPath) {
             .filter((arg) => arg.startsWith(`-`))
             .map((arg) => arg.replace(/^-+/, ``))
             .map((arg) => arg.split(/=(.*)/, 2))
-            .map(([key, value]) => [key, value !== null && value !== void 0 ? value : '']);
+            .map(([key, value]) => [key, value !== null && value !== void 0 ? value : ""]);
         const userArgsMap = new Map(userArgsList);
         const userArgNames = new Set(userArgsList.map(([key, value]) => key));
-        const formats = userArgsMap.get('out-format');
+        const formats = userArgsMap.get("out-format");
         if (formats) {
-            if (formats.includes('github-actions')) {
+            if (formats.includes("github-actions")) {
                 addedArgs.push(`--out-format=${formats}`);
             }
             else {

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -66581,21 +66581,17 @@ function runLint(lintPath, patchPath) {
             .filter((arg) => arg.startsWith(`-`))
             .map((arg) => arg.replace(/^-+/, ``))
             .map((arg) => arg.split(/=(.*)/, 2))
-            .map(([key, value]) => [key, value !== null && value !== void 0 ? value : ""]);
+            .map(([key, value]) => [key.toLowerCase(), value !== null && value !== void 0 ? value : ""]);
         const userArgsMap = new Map(userArgsList);
-        const userArgNames = new Set(userArgsList.map(([key, value]) => key));
-        const formats = userArgsMap.get("out-format");
-        if (formats) {
-            if (formats.includes("github-actions")) {
-                addedArgs.push(`--out-format=${formats}`);
-            }
-            else {
-                addedArgs.push(`--out-format=github-actions,${formats}`);
-            }
-        }
-        else {
-            addedArgs.push(`--out-format=github-actions`);
-        }
+        const userArgNames = new Set(userArgsList.map(([key]) => key));
+        const formats = (userArgsMap.get("out-format") || "")
+            .trim()
+            .split(",")
+            .filter((f) => f.length > 0)
+            .filter((f) => !f.startsWith(`github-actions`))
+            .concat("github-actions")
+            .join(",");
+        addedArgs.push(`--out-format=${formats}`);
         if (patchPath) {
             if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {
                 throw new Error(`please, don't specify manually --new* args when requesting only new issues`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -125,21 +125,20 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
     .filter((arg) => arg.startsWith(`-`))
     .map((arg) => arg.replace(/^-+/, ``))
     .map((arg) => arg.split(/=(.*)/, 2))
-    .map<[string, string]>(([key, value]) => [key, value ?? ""])
+    .map<[string, string]>(([key, value]) => [key.toLowerCase(), value ?? ""])
 
   const userArgsMap = new Map<string, string>(userArgsList)
-  const userArgNames = new Set<string>(userArgsList.map(([key, value]) => key))
+  const userArgNames = new Set<string>(userArgsList.map(([key]) => key))
 
-  const formats = userArgsMap.get("out-format")
-  if (formats) {
-    if (formats.includes("github-actions")) {
-      addedArgs.push(`--out-format=${formats}`)
-    } else {
-      addedArgs.push(`--out-format=github-actions,${formats}`)
-    }
-  } else {
-    addedArgs.push(`--out-format=github-actions`)
-  }
+  const formats = (userArgsMap.get("out-format") || "")
+    .trim()
+    .split(",")
+    .filter((f) => f.length > 0)
+    .filter((f) => !f.startsWith(`github-actions`))
+    .concat("github-actions")
+    .join(",")
+
+  addedArgs.push(`--out-format=${formats}`)
 
   if (patchPath) {
     if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -125,15 +125,15 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
     .filter((arg) => arg.startsWith(`-`))
     .map((arg) => arg.replace(/^-+/, ``))
     .map((arg) => arg.split(/=(.*)/, 2))
-    .map<[string, string]>(([key, value]) => [key, value ?? ''])
-  
-  const userArgsMap = new Map<string, string>(userArgsList)
-  const userArgNames = new Set<string>(userArgsList.map(([key, value]) => key));
+    .map<[string, string]>(([key, value]) => [key, value ?? ""])
 
-  const formats = userArgsMap.get('out-format')
+  const userArgsMap = new Map<string, string>(userArgsList)
+  const userArgNames = new Set<string>(userArgsList.map(([key, value]) => key))
+
+  const formats = userArgsMap.get("out-format")
   if (formats) {
-    if (formats.includes('github-actions')) {
-      addedArgs.push(`--out-format=${formats}`);
+    if (formats.includes("github-actions")) {
+      addedArgs.push(`--out-format=${formats}`)
     } else {
       addedArgs.push(`--out-format=github-actions,${formats}`)
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -119,18 +119,27 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
   const userArgs = core.getInput(`args`)
   const addedArgs: string[] = []
 
-  const userArgNames = new Set<string>(
-    userArgs
-      .trim()
-      .split(/\s+/)
-      .map((arg) => arg.split(`=`)[0])
-      .filter((arg) => arg.startsWith(`-`))
-      .map((arg) => arg.replace(/^-+/, ``))
-  )
-  if (userArgNames.has(`out-format`)) {
-    throw new Error(`please, don't change out-format for golangci-lint: it can be broken in a future`)
+  const userArgsList = userArgs
+    .trim()
+    .split(/\s+/)
+    .filter((arg) => arg.startsWith(`-`))
+    .map((arg) => arg.replace(/^-+/, ``))
+    .map((arg) => arg.split(/=(.*)/, 2))
+    .map<[string, string]>(([key, value]) => [key, value ?? ''])
+  
+  const userArgsMap = new Map<string, string>(userArgsList)
+  const userArgNames = new Set<string>(userArgsList.map(([key, value]) => key));
+
+  const formats = userArgsMap.get('out-format')
+  if (formats) {
+    if (formats.includes('github-actions')) {
+      addedArgs.push(`--out-format=${formats}`);
+    } else {
+      addedArgs.push(`--out-format=github-actions,${formats}`)
+    }
+  } else {
+    addedArgs.push(`--out-format=github-actions`)
   }
-  addedArgs.push(`--out-format=github-actions`)
 
   if (patchPath) {
     if (userArgNames.has(`new`) || userArgNames.has(`new-from-rev`) || userArgNames.has(`new-from-patch`)) {


### PR DESCRIPTION
This PR adds support for `--out-format` as supported arguments.

when not set, behavior is unchanged and the `github-actions` format is added.
When set, and `github-actions` is not given, it is added as the first output, otherwise, it is not added.
Any other provided format is preserved.

Fixes #458
Fixes #362
Closes #613
