### PR TITLE
chore: bump to use node20 runtime, actions/checkout to v4

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head of the pull request.

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
     default: "binary"
     required: false
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/run/index.js"
   post: "dist/post_run/index.js"
 branding:


### PR DESCRIPTION
## Description and Context:

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to node20 (Node 20). I have also bumped the actions/checkout version to v4 for the same.

Related issue:

https://github.com/actions/runner/pull/2732

----

A major version bump might be needed after the PRs merge.