### PR TITLE
feat: add option to not save cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ jobs:
           #           takes precedence over all other caching options.
           # skip-cache: true
 
+          # Optional: if set to true, caches will not be saved, but they may still be restored,
+          #           subject to other options
+          # skip-save-cache: true
+
           # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
           # skip-pkg-cache: true
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,12 @@ inputs:
       takes precedence over all other caching options.
     default: 'false'
     required: false
+  skip-save-cache:
+    description: |
+      if set to true then the action will not save any caches, but it may still
+      restore existing caches, subject to other options.
+    default: 'false'
+    required: false
   skip-pkg-cache:
     description: "if set to true then the action doesn't cache or restore ~/go/pkg."
     default: 'false'

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -88900,6 +88900,8 @@ exports.restoreCache = restoreCache;
 async function saveCache() {
     if (core.getInput(`skip-cache`, { required: true }).trim() == "true")
         return;
+    if (core.getInput(`skip-save-cache`, { required: true }).trim() == "true")
+        return;
     // Validate inputs, this can cause task failure
     if (!utils.isValidEvent()) {
         utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -88900,6 +88900,8 @@ exports.restoreCache = restoreCache;
 async function saveCache() {
     if (core.getInput(`skip-cache`, { required: true }).trim() == "true")
         return;
+    if (core.getInput(`skip-save-cache`, { required: true }).trim() == "true")
+        return;
     // Validate inputs, this can cause task failure
     if (!utils.isValidEvent()) {
         utils.logWarning(`Event Validation Error: The event type ${process.env[constants_1.Events.Key]} is not supported because it's not tied to a branch or tag ref.`);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -116,6 +116,7 @@ export async function restoreCache(): Promise<void> {
 
 export async function saveCache(): Promise<void> {
   if (core.getInput(`skip-cache`, { required: true }).trim() == "true") return
+  if (core.getInput(`skip-save-cache`, { required: true }).trim() == "true") return
 
   // Validate inputs, this can cause task failure
   if (!utils.isValidEvent()) {


### PR DESCRIPTION
Add a separate `skip-save-cache` option that, when set to true, will avoid saving caches even if restoring caches are
enabled by other options.

This will allow caches to be utilized while preventing cache bloat in various situations, e.g. on Github merge queue
branches, which are essentially throwaway branches.

Resolves #641