### PR TITLE
docs(version): change to v2 in README multiple OS support example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
           go-version: ${{ matrix.go }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v2
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.


### PR DESCRIPTION
## Changes

The README section on **multiple OS support** states that "If you need to run linters for specific operating systems, you will need to use `v2` of the action. Here is a sample configuration file:", 

However, the sample configuration .yml file in the main README shows to use the `v3` of the action.

This PR changes to use `v2` in the example .yml as the documentation states.