### PR TITLE
docs: update section about GitHub Annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,24 @@ You will also likely need to add the following `.gitattributes` file to ensure t
 
 ## Comments and Annotations
 
-Currently, GitHub parses the action's output and creates [annotations](https://github.community/t5/GitHub-Actions/What-are-annotations/td-p/30770).
+Currently, GitHub parses the action's output and creates [annotations](https://github.blog/2018-12-14-introducing-check-runs-and-annotations/).
 
 The restrictions of annotations are the following:
 
 1. Currently, they don't support markdown formatting (see the [feature request](https://github.community/t5/GitHub-API-Development-and/Checks-Ability-to-include-Markdown-in-line-annotations/m-p/56704))
 2. They aren't shown in the list of comments like it was with [golangci.com](https://golangci.com). If you would like to have comments - please, up-vote [the issue](https://github.com/golangci/golangci-lint-action/issues/5).
+
+To enable annotations, you need to add the `checks' permission to your action.
+
+```yaml annotate
+permissions:
+  # Required: allow read access to the content for analysis.
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+  # Optional: Allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
+```
 
 ## Performance
 


### PR DESCRIPTION
Annotations seem to require permissions now