### PR TITLE
Make JSON available via Outputs

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -90904,8 +90904,8 @@ const printOutputAndForwardJSON = (s) => {
             core.info(line);
         }
         try {
-            const obj = JSON.parse(line);
-            core.setOutput("JSON", JSON.stringify(obj, null, 2));
+            JSON.parse(line);
+            core.setOutput("JSON", line);
         }
         catch (err) {
             core.info(line);

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -90902,6 +90902,7 @@ const printOutputAndForwardJSON = (s) => {
     for (const line of lines) {
         if (line.startsWith(`::`)) {
             core.info(line);
+            continue;
         }
         try {
             JSON.parse(line);

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -90904,8 +90904,8 @@ const printOutputAndForwardJSON = (s) => {
             core.info(line);
         }
         try {
-            const obj = JSON.parse(line);
-            core.setOutput("JSON", JSON.stringify(obj, null, 2));
+            JSON.parse(line);
+            core.setOutput("JSON", line);
         }
         catch (err) {
             core.info(line);

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -90902,6 +90902,7 @@ const printOutputAndForwardJSON = (s) => {
     for (const line of lines) {
         if (line.startsWith(`::`)) {
             core.info(line);
+            continue;
         }
         try {
             JSON.parse(line);

--- a/src/run.ts
+++ b/src/run.ts
@@ -108,6 +108,7 @@ const printOutputAndForwardJSON = (s: string): void => {
   for (const line of lines) {
     if (line.startsWith(`::`)) {
       core.info(line)
+      continue
     }
 
     try {

--- a/src/run.ts
+++ b/src/run.ts
@@ -103,7 +103,7 @@ type ExecRes = {
   stderr: string
 }
 
-const printJSONLines = (s: string): void => {
+const printOutputAndForwardJSON = (s: string): void => {
   const lines = s.split(`\n`).filter((line) => line.length > 0)
   for (const line of lines) {
     if (line.startsWith(`::`)) {
@@ -112,7 +112,7 @@ const printJSONLines = (s: string): void => {
 
     try {
       const obj = JSON.parse(line)
-      core.setOutput('json', JSON.stringify(obj, null, 2))
+      core.setOutput("JSON", JSON.stringify(obj, null, 2))
     } catch (err) {
       core.info(line)
     }
@@ -121,10 +121,10 @@ const printJSONLines = (s: string): void => {
 
 const printOutput = (res: ExecRes): void => {
   if (res.stdout) {
-    printJSONLines(res.stdout)
+    printOutputAndForwardJSON(res.stdout)
   }
   if (res.stderr) {
-    printJSONLines(res.stderr)
+    printOutputAndForwardJSON(res.stderr)
   }
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -103,12 +103,28 @@ type ExecRes = {
   stderr: string
 }
 
+const printJSONLines = (s: string): void => {
+  const lines = s.split(`\n`).filter((line) => line.length > 0)
+  for (const line of lines) {
+    if (line.startsWith(`::`)) {
+      core.info(line)
+    }
+
+    try {
+      const obj = JSON.parse(line)
+      core.setOutput('json', JSON.stringify(obj, null, 2))
+    } catch (err) {
+      core.info(line)
+    }
+  }
+}
+
 const printOutput = (res: ExecRes): void => {
   if (res.stdout) {
-    core.info(res.stdout)
+    printJSONLines(res.stdout)
   }
   if (res.stderr) {
-    core.info(res.stderr)
+    printJSONLines(res.stderr)
   }
 }
 
@@ -137,8 +153,9 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
     .trim()
     .split(",")
     .filter((f) => f.length > 0)
-    .filter((f) => !f.startsWith(`github-actions`))
+    .filter((f) => !f.startsWith(`github-actions`) && !f.startsWith(`json`))
     .concat("github-actions")
+    .concat("json")
     .join(",")
 
   addedArgs.push(`--out-format=${formats}`)

--- a/src/run.ts
+++ b/src/run.ts
@@ -111,8 +111,8 @@ const printOutputAndForwardJSON = (s: string): void => {
     }
 
     try {
-      const obj = JSON.parse(line)
-      core.setOutput("JSON", JSON.stringify(obj, null, 2))
+      JSON.parse(line)
+      core.setOutput("JSON", line)
     } catch (err) {
       core.info(line)
     }


### PR DESCRIPTION
It can be useful to pass the machine-readable results of a linting run to later CI steps to power customizations like notifications or PR comments

This change requests JSON output from `golangci-lint`, grabs the results, and makes them available in the action's outputs under the key `JSON`