### PR TITLE
docs: update the version of the action used in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The action runs [golangci-lint](https://github.com/golangci/golangci-lint) and r
 
 ## Compatibility
 
-* `v3.0.0+` requires explicit setup-go installation step prior to using this action: `uses: actions/setup-go@v5`.
+* `v4.0.0+` requires an explicit setup-go installation step before using this action: `uses: actions/setup-go@v5`.
   The `skip-go-installation` option has been removed.
 * `v2.0.0+` works with `golangci-lint` version >= `v1.28.3`
 * `v1.2.2` is deprecated due to we forgot to change the minimum version of `golangci-lint` to `v1.28.3` ([issue](https://github.com/golangci/golangci-lint-action/issues/39))

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The action runs [golangci-lint](https://github.com/golangci/golangci-lint) and r
 
 ## Compatibility
 
-* `v3.0.0+` requires explicit setup-go installation step prior to using this action: `uses: actions/setup-go@v3`.
+* `v3.0.0+` requires explicit setup-go installation step prior to using this action: `uses: actions/setup-go@v5`.
   The `skip-go-installation` option has been removed.
 * `v2.0.0+` works with `golangci-lint` version >= `v1.28.3`
 * `v1.2.2` is deprecated due to we forgot to change the minimum version of `golangci-lint` to `v1.28.3` ([issue](https://github.com/golangci/golangci-lint-action/issues/39))
@@ -38,13 +38,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
@@ -107,13 +107,13 @@ jobs:
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.


### PR DESCRIPTION
- `actions/checkout@v3` -> `actions/checkout@v4`
- `actions/setup-go@v4` -> `actions/setup-go@v5`
- `golangci/golangci-lint-action@v3` -> `golangci/golangci-lint-action@v4`