### PR TITLE
feat: support for `pull` and `merge_group` events with the option `only-new-issues`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ jobs:
           # The location of the configuration file can be changed by using `--config=`
           # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0 
 
-          # Optional: For pull request only, show only new issues. The default value is `false`.
+          # Optional: Show only new issues.
+          # If you are using `merge_group` event (merge queue) you should add the option `fetch-depth: 0` to `actions/checkout` step.
+          # The default value is `false`.
           # only-new-issues: true
 
           # Optional: if set to true, then all caching functionality will be completely disabled,
@@ -104,7 +106,7 @@ jobs:
     strategy:
       matrix:
         go: ['1.21']
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
@@ -129,7 +131,9 @@ jobs:
           # The location of the configuration file can be changed by using `--config=`
           # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0 
 
-          # Optional: For pull request only, show only new issues. The default value is `false`.
+          # Optional: Show only new issues.
+          # If you are using `merge_group` event (merge queue) you should add the option `fetch-depth: 0` to `actions/checkout` step.
+          # The default value is `false`.
           # only-new-issues: true
 
           # Optional: if set to true, then all caching functionality will be completely disabled,

--- a/src/run.ts
+++ b/src/run.ts
@@ -46,6 +46,9 @@ async function fetchPatch(): Promise<string> {
       return await fetchPullRequestPatch(ctx)
     case `push`:
       return await fetchPushPatch(ctx)
+    case `merge_group`:
+      core.info(JSON.stringify(ctx.payload))
+      return ``
     default:
       core.info(`Not fetching patch for showing only new issues because it's not a pull request context: event name is ${ctx.eventName}`)
       return ``
@@ -220,6 +223,13 @@ async function runLint(lintPath: string, patchPath: string): Promise<void> {
           addedArgs.push(`--new=false`)
           addedArgs.push(`--new-from-rev=`)
         }
+        break
+      case `merge_group`:
+        addedArgs.push(`--new-from-rev=${ctx.payload.merge_group.base_sha}`)
+
+        // Override config values.
+        addedArgs.push(`--new=false`)
+        addedArgs.push(`--new-from-patch=`)
         break
       default:
         break


### PR DESCRIPTION
This PR adds support for `pull` and `merge_group` events with the option `only-new-issues`.

`merge_group` event demo: https://github.com/golangci/super-waffle/pull/1

Fixes #956
Fixes #531
Closes #520