### PR TITLE
feat: uses 2 dots compare syntax for push diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,6 @@ with:
 
 Show only new issues.
 
-If you are using `merge_group` event (merge queue) you should add the option `fetch-depth: 0` to `actions/checkout` step.
-
 The default value is `false`.
 
 ```yml
@@ -147,6 +145,11 @@ with:
   only-new-issues: true
   # ...
 ```
+
+* `pull_request` and `pull_request_target`: the action gets the diff of the PR content from the [GitHub API](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request) and use it with `--new-from-patch`.
+* `push`: the action gets the diff of the push content (difference between commits before and after the push) from the [GitHub API](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits) and use it with `--new-from-patch`.
+* `merge_group`: the action gets the diff by using `--new-from-rev` option (relies on git).
+   You should add the option `fetch-depth: 0` to `actions/checkout` step.
 
 ### `working-directory`
 

--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -89221,11 +89221,10 @@ async function fetchPushPatch(ctx) {
     const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
     let patch;
     try {
-        const patchResp = await octokit.rest.repos.compareCommits({
+        const patchResp = await octokit.rest.repos.compareCommitsWithBasehead({
             owner: ctx.repo.owner,
             repo: ctx.repo.repo,
-            base: ctx.payload.before,
-            head: ctx.payload.after,
+            basehead: `${ctx.payload.before}..${ctx.payload.after}`,
             mediaType: {
                 format: `diff`,
             },

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -89221,11 +89221,10 @@ async function fetchPushPatch(ctx) {
     const octokit = github.getOctokit(core.getInput(`github-token`, { required: true }));
     let patch;
     try {
-        const patchResp = await octokit.rest.repos.compareCommits({
+        const patchResp = await octokit.rest.repos.compareCommitsWithBasehead({
             owner: ctx.repo.owner,
             repo: ctx.repo.repo,
-            base: ctx.payload.before,
-            head: ctx.payload.after,
+            basehead: `${ctx.payload.before}..${ctx.payload.after}`,
             mediaType: {
                 format: `diff`,
             },

--- a/src/run.ts
+++ b/src/run.ts
@@ -104,11 +104,10 @@ async function fetchPushPatch(ctx: Context): Promise<string> {
 
   let patch: string
   try {
-    const patchResp = await octokit.rest.repos.compareCommits({
+    const patchResp = await octokit.rest.repos.compareCommitsWithBasehead({
       owner: ctx.repo.owner,
       repo: ctx.repo.repo,
-      base: ctx.payload.before,
-      head: ctx.payload.after,
+      basehead: `${ctx.payload.before}..${ctx.payload.after}`,
       mediaType: {
         format: `diff`,
       },


### PR DESCRIPTION
`compareCommits` is deprecated and replaced by `compareCommitsWithBasehead`.

`compareCommitsWithBasehead` allows usage of 2-dot compare syntax (only files content diff) instead of the 3-dot (commits and files).
