### PR TITLE
feat: rewrite format handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The action runs [golangci-lint](https://github.com/golangci/golangci-lint) and r
 
 ## Compatibility
 
+* `v6.0.0+` removes `annotations` option.
 * `v5.0.0+` removes `skip-pkg-cache` and `skip-build-cache` because the cache related to Go itself is already handled by `actions/setup-go`.
 * `v4.0.0+` requires an explicit `actions/setup-go` installation step before using this action: `uses: actions/setup-go@v5`.
   The `skip-go-installation` option has been removed.
@@ -212,23 +213,24 @@ with:
 
 If set the number is `<= 0`, the cache will be always invalidate (Not recommended).
 
-### `annotations`
+### `problem-matchers`
 
 (optional)
 
-To enable/disable GitHub Action annotations.
+Force the usage of the embedded problem matchers.
 
-If disabled (`false`), the output format(s) will follow the golangci-lint configuration file (or CLI flags from `args`) 
-and use the same default as golangci-lint (i.e. `colored-line-number`).
+By default, the [problem matcher of Go (`actions/setup-go`)](https://github.com/actions/setup-go/blob/main/matchers.json) already handles the golangci-lint output (`colored-line-number`). 
+
+Works only with `colored-line-number` (the golangci-lint default).
 
 https://golangci-lint.run/usage/configuration/#output-configuration
 
-The default value is `true`.
+The default value is `false`.
 
 ```yml
 uses: golangci/golangci-lint-action@v5
 with:
-  annotations: false
+  problem-matchers: true
   # ...
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,9 @@ inputs:
       restore existing caches, subject to other options.
     default: 'false'
     required: false
-  annotations:
-    description: "To Enable/disable GitHub Action annotations"
-    default: 'true'
+  problem-matchers:
+    description: "Force the usage of the embedded problem matchers"
+    default: 'false'
     required: false
   args:
     description: "golangci-lint command line arguments"

--- a/problem-matchers.json
+++ b/problem-matchers.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "golangci-lint-colored-line-number",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):(?:(\\d+):)?\\s+(.+ \\(.+\\))$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- remove the code inside the golangci-lint action that forces the output format to use `github-actions`
- remove the option `annotations` of this action because it's useless
- add an option to force adding the problem matchers of golangci-lint inside the action.

https://github.com/golangci/golangci-lint/issues/4695#issuecomment-2097087189