### PR TITLE
docs: update local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,6 @@ This scheme is basic and needs improvements. Pull requests and ideas are welcome
 
 1. Install [act](https://github.com/nektos/act#installation)
 2. Make a symlink for `act` to work properly: `ln -s . golangci-lint-action`
-3. Install Typescript
-4. Prepare deps once: `npm install`
-5. Build: `npm run build`
-6. Run `npm run local` after any change to test it
+3. Install dependencies: `npm install`
+4. Build: `npm run build`
+5. Run `npm run local` after any change to test it

--- a/README.md
+++ b/README.md
@@ -544,5 +544,7 @@ This scheme is basic and needs improvements. Pull requests and ideas are welcome
 
 1. Install [act](https://github.com/nektos/act#installation)
 2. Make a symlink for `act` to work properly: `ln -s . golangci-lint-action`
-3. Prepare deps once: `npm run prepare-deps`
-4. Run `npm run local` after any change to test it
+3. Instally typescript (on a Mac, `brew install tsc`)
+4. Prepare deps once: `npm install`
+5. Build: `npm run build`
+6. Run `npm run local` after any change to test it

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ This scheme is basic and needs improvements. Pull requests and ideas are welcome
 
 1. Install [act](https://github.com/nektos/act#installation)
 2. Make a symlink for `act` to work properly: `ln -s . golangci-lint-action`
-3. Instally typescript (on a Mac, `brew install tsc`)
+3. Install Typescript
 4. Prepare deps once: `npm install`
 5. Build: `npm run build`
 6. Run `npm run local` after any change to test it


### PR DESCRIPTION
PR updates the local development instructions in README.md that are currently causing errors since `npm run` doesn't contain `prepare-dips`.

Fixes #1124