### PR TITLE
docs: update README options version from required to optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ You will also likely need to add the following `.gitattributes` file to ensure t
 
 ### `version`
 
-(required)
+(optional)
 
 The version of golangci-lint to use.
 


### PR DESCRIPTION
This action can be executed without specifying a version.
I have confirmed in [action.yml](https://github.com/golangci/golangci-lint-action/blob/master/action.yml) and [version.ts](https://github.com/golangci/golangci-lint-action/blob/master/src/version.ts) that it is a working implementation even if it is not required.