### PR TITLE
feat: verify with the JSONSchema by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,6 @@ jobs:
           version: ${{ matrix.version }}
           args: --timeout=5m --issues-exit-code=0 ./sample/...
           only-new-issues: true
-          verify: true
 
   test-go-install: # make sure the action works on a clean machine without building (go-install mode)
     needs: [ build ]
@@ -101,7 +100,6 @@ jobs:
           args: --timeout=5m --issues-exit-code=0 ./sample/...
           only-new-issues: true
           install-mode: goinstall
-          verify: true
 
   test-go-mod:
     needs: [ build ]
@@ -127,4 +125,3 @@ jobs:
         with:
           working-directory: ${{ matrix.wd }}
           args: --timeout=5m --issues-exit-code=0 ./...
-          verify: true

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
   verify:
     description: "if set to true and the action verify the configuration file against the JSONSchema"
-    default: 'false'
+    default: 'true'
     required: false
   only-new-issues:
     description: "if set to true and the action runs on a pull request - the action outputs only newly found issues"


### PR DESCRIPTION
By detecting if a configuration file is present (or set with `--config=`), we can run the verification of the configuration file by default.

The verification can be disabled by setting `verify` to false.