### PR TITLE
README: Add notes for annotation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,8 @@ permissions:
   checks: write
 ```
 
+Make sure to use `actions/setup-go` in the job as that's needed for the problem matcher and use the `colored-line-number` output (golangci-lint default).
+
 ## Performance
 
 The action was implemented with performance in mind:


### PR DESCRIPTION
I tried to configure annotations and it didn't fully function as I wasn't using `setup-go` in the same job (but did in other jobs in the same config). This note might help others to avoid the same issue.

Instead of setup-go the problem matcher of golangci-lint-action also works, but I assume that's not the recommended way as the examples all use setup-go.