### PR TITLE
docs: add note about github.workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ The location of the configuration file can be changed by using `--config=`
 ```yml
 uses: golangci/golangci-lint-action@v7
 with:
-  args: --config=/my/path/.golangci.yml --issues-exit-code=0
+  args: --config=${{ github.workspace }}/my/path/.golangci.yml --issues-exit-code=0
   # ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,9 @@ The location of the configuration file can be changed by using `--config=`
 ```yml
 uses: golangci/golangci-lint-action@v7
 with:
-  args: --config=${{ github.workspace }}/my/path/.golangci.yml --issues-exit-code=0
+  # In some rare cases,
+  # you could have to use `${{ github.workspace }}` as base directory to reference your configuration file.
+  args: --config=/my/path/.golangci.yml --issues-exit-code=0
   # ...
 ```
 


### PR DESCRIPTION
I struggled a bit with setting the path to a config file until I realized that the path needs to be a full absolute path on disk when Github Actions runs it.  Using the `github.workspace` context variable seems to be the easiest solution.

Just thought I would document it to save someone else from the frustration.