### PR TITLE
feat: add support for reading golangci-lint version from go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,68 @@ You will also likely need to add the following `.gitattributes` file to ensure t
 </details>
 
 <details>
+<summary>Using go.mod Version Example</summary>
+
+If you have golangci-lint as a dependency in your go.mod file, you can use that version automatically:
+
+```yaml
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        # No version specified - will read from go.mod automatically
+```
+
+Or if you have a separate tools module:
+
+```yaml
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          go-mod-path: tools/go.mod
+```
+
+</details>
+
+<details>
 <summary>Go Workspace Example</summary>
 
 ```yaml
@@ -280,6 +342,29 @@ with:
 
 </details>
 
+### `go-mod-path`
+
+(optional)
+
+Path to a go.mod file to read the golangci-lint version from.
+If specified and `version` is not set, the action will parse the go.mod file to determine the golangci-lint version.
+
+Default is "go.mod" in the working directory.
+
+**Note:** When a version is read from go.mod, it automatically uses `goinstall` install-mode to ensure compatibility with your module's dependencies.
+
+<details>
+<summary>Example</summary>
+
+```yml
+uses: golangci/golangci-lint-action@v8
+with:
+  go-mod-path: tools/go.mod
+  # ...
+```
+
+</details>
+
 ### `install-mode`
 
 (optional)
@@ -287,6 +372,8 @@ with:
 The mode to install golangci-lint: it can be `binary`, `goinstall`, or `none`.
 
 The default value is `binary`.
+
+**Note:** When using `go-mod-path` to read the version from a go.mod file, the install-mode is automatically set to `goinstall`.
 
 <details>
 <summary>Example</summary>

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,13 @@ inputs:
       - `goinstall`: the value can be v2.3.4, `latest`, or the hash of a commit.
       - `none`: the value is ignored.
     required: false
+  go-mod-path:
+    description: |
+      Path to a go.mod file to read the golangci-lint version from.
+      If specified and version is not set, the action will parse the go.mod file
+      to determine the golangci-lint version. Default is "go.mod" in the working directory.
+      Note: When a version is read from go.mod, it automatically uses `goinstall` install-mode.
+    required: false
   install-mode:
     description: "The mode to install golangci-lint. It can be 'binary', 'goinstall', or 'none'."
     default: "binary"


### PR DESCRIPTION
Implements automatic version detection from go.mod files to keep golangci-lint versions synchronized between the module and CI.

- Add new `go-mod-path` input parameter to specify custom go.mod location
- Automatically detect and use version from go.mod when no explicit version provided
- Force `goinstall` mode when using go.mod versions for compatibility
- Support both default go.mod and custom paths (e.g., tools/go.mod)

This eliminates the need to manually update versions in multiple places and ensures CI uses the same golangci-lint version as the project.

Fixes #1268