### PR TITLE
Skip custom install when install mode is "none"

### DIFF
--- a/dist/post_run/index.js
+++ b/dist/post_run/index.js
@@ -59234,6 +59234,10 @@ async function install(binPath) {
     if (!configFile || configFile === "") {
         return binPath;
     }
+    const installMode = core.getInput(`install-mode`).toLowerCase();
+    if (installMode === "none") {
+        return binPath;
+    }
     core.info(`Found configuration for the plugin module system : ${configFile}`);
     core.info(`Building and installing custom golangci-lint binary...`);
     const startedAt = Date.now();

--- a/dist/run/index.js
+++ b/dist/run/index.js
@@ -59234,6 +59234,10 @@ async function install(binPath) {
     if (!configFile || configFile === "") {
         return binPath;
     }
+    const installMode = core.getInput(`install-mode`).toLowerCase();
+    if (installMode === "none") {
+        return binPath;
+    }
     core.info(`Found configuration for the plugin module system : ${configFile}`);
     core.info(`Building and installing custom golangci-lint binary...`);
     const startedAt = Date.now();

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -42,6 +42,11 @@ export async function install(binPath: string): Promise<string> {
   if (!configFile || configFile === "") {
     return binPath
   }
+  
+  const installMode = core.getInput(`install-mode`).toLowerCase()
+  if (installMode === "none" ) {
+    return binPath
+  }
 
   core.info(`Found configuration for the plugin module system : ${configFile}`)
 


### PR DESCRIPTION
When the configuration `install-mode: none` is passed and a `.custom-gcl.yml` file was available in the repository the action would still try to install this custom version during the plugin step. It does successfully skip the installation during the installation step.

Instead it should use the existing executable at the binPath.
